### PR TITLE
Implementación de página Default.aspx

### DIFF
--- a/Base de Datos/Obligatorio.sql
+++ b/Base de Datos/Obligatorio.sql
@@ -9,11 +9,11 @@ begin
 end
 GO
 
-CREATE DATABASE Obligatorio ON
-(
-	NAME=Obligatorio,
-	FILENAME='C:\BD\Obligatorio.mdf'
-)
+CREATE DATABASE Obligatorio 
+--ON(
+--	NAME=Obligatorio,
+--	FILENAME='C:\BD\Obligatorio.mdf'
+--)
 GO
 
 USE Obligatorio
@@ -321,6 +321,7 @@ EXEC AltaSeccion 'depor','Deportes'
 EXEC AltaSeccion 'cultu','Cultural'
 EXEC AltaSeccion 'viaje','Viajes'
 EXEC ModificarSeccion 'cultu','Cultura'
+EXEC AltaSeccion 'inter','Internacionales'
 GO
 
 EXEC AltaPeriodista '44259772', 'Periodista 1', 'period1@gmail.com'
@@ -332,18 +333,39 @@ EXEC ModificarPeriodista '67839025', 'Periodista 6', 'period6@gmail.com'
 GO
 
 
+INSERT INTO Noticias(Codigo, Titulo, Cuerpo, Importancia, FechaPublicacion, CodigoSeccion, NombreUsuario)
+Values('codnot1', 'Titulo Noticia 1','Cuerpo Noticia 1', 4,'20211017', 'polic', 'Empleado10'),
+('codnot2', 'Titulo Noticia 2','Cuerpo Noticia 2', 3,'20201013', 'econo', 'Empleado10'),
+('codnot3', 'Titulo Noticia 3','Cuerpo Noticia 3', 4,'20211027', 'polic', 'Empleado30'),
+('codnot4', 'Titulo Noticia 4','Cuerpo Noticia 4', 1,'20201013', 'cultu', 'Empleado30'),
+('codnot5', 'Titulo Noticia 5','Cuerpo Noticia 5', 4,'20211028', 'polic', 'Empleado10'),
+('codnot6', 'Titulo Noticia 6','Cuerpo Noticia 6', 5,'20211029', 'econo', 'Empleado10'),
+('codnot7', 'Titulo Noticia 7','Cuerpo Noticia 7', 2,'20210820', 'cultu', 'Empleado20'),
+('codnot8', 'Titulo Noticia 8','Cuerpo Noticia 8', 2,'20210821', 'econo', 'Empleado30'),
+('codnot9', 'Titulo Noticia 9','Cuerpo Noticia 9', 5,'20211029', 'inter', 'Empleado10'),
+('codnot10', 'Titulo Noticia 10','Cuerpo Noticia 10', 3,'20191012', 'inter', 'Empleado40'),
+('codnot11', 'Titulo Noticia 11','Cuerpo Noticia 11', 4,'20211029', 'inter', 'Empleado20'),
+('codnot12', 'Titulo Noticia 12','Cuerpo Noticia 12', 3,'20191012', 'inter', 'Empleado40'),
+('codnot13', 'Titulo Noticia 13','Cuerpo Noticia 13', 1,'20210809', 'inter', 'Empleado30'),
+('codnot14', 'Titulo Noticia 14','Cuerpo Noticia 14', 3,'20211104', 'inter', 'Empleado20'),
+('codnot15', 'Titulo Noticia 15','Cuerpo Noticia 15', 3,'20211105', 'inter', 'Empleado20'),
+('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,'20211106', 'inter', 'Empleado40')
+GO
+
 SELECT * FROM Empleados
 SELECT * FROM Secciones
 SELECT * FROM Periodistas
 SELECT * FROM Noticias
 SELECT * FROM Escriben
 
+/*
 ALTER TABLE Noticias WITH NOCHECK
 	ADD CONSTRAINT VerificarAño
 	-- si FechaPublicacion es menor a GETDATE()
 	-- DATEDIFF producirá un valor menor a 0
 	CHECK(DATEDIFF(day,GETDATE(),FechaPublicacion) >= 0) 
 GO
+*/
 
 --Creacion de usuario IIS para que el sitio pueda acceder a la BD-------------------------------------------
 USE master

--- a/ModeloEF/App.Config
+++ b/ModeloEF/App.Config
@@ -1,20 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <configSections>
-        <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
-        <section name="entityFramework"
-          type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
-          requirePermission="false"/>
-    </configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
   <connectionStrings>
-    <add name="ObligatorioEntities"
-      connectionString="metadata=res://*/Obligatorio.csdl|res://*/Obligatorio.ssdl|res://*/Obligatorio.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=.;initial catalog=Obligatorio;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;"
-      providerName="System.Data.EntityClient"/>
+    <add name="ObligatorioEntities" connectionString="metadata=res://*/Obligatorio.csdl|res://*/Obligatorio.ssdl|res://*/Obligatorio.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=.;initial catalog=Obligatorio;integrated security=True;MultipleActiveResultSets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />
   </connectionStrings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2"/></startup>
-<entityFramework>
-<providers>
-<provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer"/>
-</providers>
-</entityFramework>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  </startup>
+  <entityFramework>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+    </providers>
+  </entityFramework>
 </configuration>

--- a/ModeloEF/Empleados.cs
+++ b/ModeloEF/Empleados.cs
@@ -14,16 +14,7 @@ namespace ModeloEF
     
     public partial class Empleados
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-        public Empleados()
-        {
-            this.Noticias = new HashSet<Noticias>();
-        }
-    
         public string NombreUsuario { get; set; }
         public string Contraseña { get; set; }
-    
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual HashSet<Noticias> Noticias { get; set; }
     }
 }

--- a/ModeloEF/ModeloEF.csproj
+++ b/ModeloEF/ModeloEF.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project=".\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props" Condition="Exists('.\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props')" />
   <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
+  <Import Project=".\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props" Condition="Exists('.\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,11 +39,9 @@
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
@@ -122,13 +120,15 @@
     <PropertyGroup>
       <ErrorText>Este proyecto hace referencia a los paquetes NuGet que faltan en este equipo. Use la restauración de paquetes NuGet para descargarlos. Para obtener más información, consulte http://go.microsoft.com/fwlink/?LinkID=322105. El archivo que falta es {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.props'))" />
     <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
   </Target>
   <Import Project=".\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('.\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
   <Import Project="..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\netcoreapp3.0\EntityFramework.targets')" />
+  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/ModeloEF/Obligatorio.Designer.cs
+++ b/ModeloEF/Obligatorio.Designer.cs
@@ -1,4 +1,4 @@
-﻿// La generación de código T4 está habilitada para el modelo 'C:\Users\Gonzalo\Source\Repos\Obligatorio\ModeloEF\Obligatorio.edmx'. 
+﻿// La generación de código T4 está habilitada para el modelo 'C:\Users\usuario\source\repos\Obligatorio\ModeloEF\Obligatorio.edmx'. 
 // Para habilitar la generación de código heredada, cambie el valor de la propiedad del diseñador 'Estrategia de generación de código'
 // por 'ObjectContext heredado'. Esta propiedad está disponible en la ventana Propiedades cuando se abre
 // el modelo en el diseñador.

--- a/ModeloEF/Obligatorio.edmx
+++ b/ModeloEF/Obligatorio.edmx
@@ -164,7 +164,6 @@
           </Key>
           <Property Name="NombreUsuario" Type="String" MaxLength="10" FixedLength="false" Unicode="false" Nullable="false" />
           <Property Name="Contraseña" Type="String" MaxLength="7" FixedLength="false" Unicode="false" Nullable="false" />
-          <NavigationProperty Name="Noticias" Relationship="Self.FK__Noticias__Nombre__1273C1CD" FromRole="Empleados" ToRole="Noticias" />
         </EntityType>
         <EntityType Name="Noticias">
           <Key>
@@ -189,7 +188,6 @@
           <Property Name="Nombre" Type="String" MaxLength="20" FixedLength="false" Unicode="false" Nullable="false" />
           <Property Name="Email" Type="String" MaxLength="20" FixedLength="false" Unicode="false" Nullable="false" />
           <Property Name="Activo" Type="Boolean" Nullable="false" />
-          <NavigationProperty Name="Noticias" Relationship="Self.Escriben" FromRole="Periodistas" ToRole="Noticias" />
         </EntityType>
         <EntityType Name="Secciones">
           <Key>
@@ -198,7 +196,6 @@
           <Property Name="CodigoSeccion" Type="String" MaxLength="5" FixedLength="false" Unicode="false" Nullable="false" />
           <Property Name="Nombre" Type="String" MaxLength="20" FixedLength="false" Unicode="false" Nullable="false" />
           <Property Name="Activo" Type="Boolean" Nullable="false" />
-          <NavigationProperty Name="Noticias" Relationship="Self.FK__Noticias__Codigo__1367E606" FromRole="Secciones" ToRole="Noticias" />
         </EntityType>
         <Association Name="FK__Noticias__Nombre__1273C1CD">
           <End Role="Empleados" Type="Self.Empleados" Multiplicity="1" />

--- a/ModeloEF/Periodistas.cs
+++ b/ModeloEF/Periodistas.cs
@@ -14,18 +14,9 @@ namespace ModeloEF
     
     public partial class Periodistas
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-        public Periodistas()
-        {
-            this.Noticias = new HashSet<Noticias>();
-        }
-    
         public string Cedula { get; set; }
         public string Nombre { get; set; }
         public string Email { get; set; }
         public bool Activo { get; set; }
-    
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual HashSet<Noticias> Noticias { get; set; }
     }
 }

--- a/ModeloEF/Secciones.cs
+++ b/ModeloEF/Secciones.cs
@@ -14,17 +14,8 @@ namespace ModeloEF
     
     public partial class Secciones
     {
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-        public Secciones()
-        {
-            this.Noticias = new HashSet<Noticias>();
-        }
-    
         public string CodigoSeccion { get; set; }
         public string Nombre { get; set; }
         public bool Activo { get; set; }
-    
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
-        public virtual HashSet<Noticias> Noticias { get; set; }
     }
 }

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -37,4 +37,15 @@ public class LogicaModeloEF
             throw new Exception("Usuario / Contraseña incorrectos");
         }
     }
+
+    internal static List<Noticias> MostrarNoticiasUltimosCincoDias()
+    {
+        DateTime hoy = DateTime.Now;
+
+        DateTime haceCincoDias = hoy.AddDays(-5);
+
+        return OEcontext.Noticias
+            .Where(noticia => noticia.FechaPublicacion >= haceCincoDias)
+            .ToList<Noticias>();
+    }
 }

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -321,7 +321,26 @@ public class LogicaModeloEF
 
         DateTime haceCincoDias = hoy.AddDays(-5);
 
+        /**
+         * Aquí la operación Include se utiliza para indicar al contexto
+         * que se carguen los datos de las Noticias de forma diligente,
+         * tal como se explica en el siguiente enlace: 
+         * 
+         * https://docs.microsoft.com/en-us/ef/ef6/querying/related-data#eagerly-loading
+         * 
+         * Debido a que se eliminó la doble navegabilidad del modelo para
+         * evitar referencias circulares, esta es la única forma de forzar
+         * al contexto de cargar las Noticias con los Periodistas
+         * 
+         * Luego utilicé Include para Empleados y Secciones para seguir
+         * el mismo criterio.
+         * 
+         * Rafael, 16/11/2021
+         */
         return OEcontext.Noticias
+            .Include("Periodistas")
+            .Include("Empleados")
+            .Include("Secciones")
             .Where(noticia => noticia.FechaPublicacion >= haceCincoDias)
             .ToList<Noticias>();
     }

--- a/Servicio/App_Code/ServicioEF.cs
+++ b/Servicio/App_Code/ServicioEF.cs
@@ -39,4 +39,21 @@ public class ServicioEF : System.Web.Services.WebService
 
         return emp;
     }
+
+    [WebMethod]
+    public List<Noticias> MostrarNoticiasUltimosCincoDias()
+    {
+        List <Noticias> resultado = null;
+
+        try
+        {
+            resultado = LogicaModeloEF.MostrarNoticiasUltimosCincoDias();
+        }
+        catch (Exception ex)
+        {
+            GeneroSoapException(ex);
+        }
+
+        return resultado;
+    }
 }

--- a/Servicio/App_Data/PublishProfiles/Servicio.pubxml
+++ b/Servicio/App_Data/PublishProfiles/Servicio.pubxml
@@ -6,7 +6,7 @@ editando este archivo MSBuild. Para conocer más acerca de esto, visite http://g
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <WebPublishMethod>FileSystem</WebPublishMethod>
-    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>

--- a/Sitio/ABMPeriodistas.aspx.cs
+++ b/Sitio/ABMPeriodistas.aspx.cs
@@ -36,7 +36,7 @@ public partial class ABMPeriodistas : System.Web.UI.Page
     {
         try
         {
-            Periodistas _unPeriodista = new ServicioEF().BuscarPeriodista(txtCedula.Text);
+            Periodistas _unPeriodista = new ServicioEFSoapClient().BuscarPeriodista(txtCedula.Text);
 
             if (_unPeriodista == null)
             {
@@ -90,7 +90,7 @@ public partial class ABMPeriodistas : System.Web.UI.Page
 
         try
         {
-            new ServicioEF().AltaPeriodista(P);
+            new ServicioEFSoapClient().AltaPeriodista(P);
 
             LblError.Text = "Alta con Exito";
 
@@ -118,7 +118,7 @@ public partial class ABMPeriodistas : System.Web.UI.Page
         {
             Periodistas _unPer = (Periodistas)Session["Periodista"];
 
-            new ServicioEF().EliminarPeriodista(_unPer);
+            new ServicioEFSoapClient().EliminarPeriodista(_unPer);
 
             LblError.Text = "Baja con Exito";
 
@@ -149,7 +149,7 @@ public partial class ABMPeriodistas : System.Web.UI.Page
             _unP.Nombre = txtNombre.Text.Trim();
             _unP.Email = txtEmail.Text.Trim();
 
-            new ServicioEF().ModificarPeriodista(_unP);
+            new ServicioEFSoapClient().ModificarPeriodista(_unP);
 
             LblError.Text = "Modificación con Exito";
 

--- a/Sitio/ABMSecciones.aspx.cs
+++ b/Sitio/ABMSecciones.aspx.cs
@@ -18,7 +18,7 @@ public partial class ABMSecciones : System.Web.UI.Page
     {
         try
         {
-            Secciones _unaSeccion = new ServicioEF().BuscarSeccion(txtCodigoSeccion.Text.Trim());
+            Secciones _unaSeccion = new ServicioEFSoapClient().BuscarSeccion(txtCodigoSeccion.Text.Trim());
 
             if (_unaSeccion == null)
             {
@@ -81,7 +81,7 @@ public partial class ABMSecciones : System.Web.UI.Page
 
         try
         {
-            new ServicioEF().AltaSeccion(S);
+            new ServicioEFSoapClient().AltaSeccion(S);
 
             lblMensaje.Text = "Alta con Exito";
 
@@ -108,7 +108,7 @@ public partial class ABMSecciones : System.Web.UI.Page
         {
             Secciones _unaS = (Secciones)Session["Seccion"];
 
-            new ServicioEF().EliminarSeccion(_unaS);
+            new ServicioEFSoapClient().EliminarSeccion(_unaS);
 
             lblMensaje.Text = "Baja con Exito";
 
@@ -137,7 +137,7 @@ public partial class ABMSecciones : System.Web.UI.Page
             _unaS.CodigoSeccion = txtCodigoSeccion.Text.Trim();
             _unaS.Nombre = txtNombreSeccion.Text.Trim();
 
-            new ServicioEF().ModificarSeccion(_unaS);
+            new ServicioEFSoapClient().ModificarSeccion(_unaS);
 
             lblMensaje.Text = "Modificación con Exito";
 

--- a/Sitio/AltaEmpleado.aspx.cs
+++ b/Sitio/AltaEmpleado.aspx.cs
@@ -30,7 +30,7 @@ public partial class AltaEmpleado : System.Web.UI.Page
                 Contraseña = txtContraseña.Text.Trim()
             };
 
-            new ServicioEF().AltaEmpleado(E);
+            new ServicioEFSoapClient().AltaEmpleado(E);
 
             lblError.Text = "Alta con Exito";
 
@@ -72,7 +72,7 @@ public partial class AltaEmpleado : System.Web.UI.Page
 
         //try
         //{
-        //    new ServicioEF().AltaEmpleado(E);
+        //    new ServicioEFSoapClient().AltaEmpleado(E);
 
         //    lblError.Text = "Alta con Exito";
 

--- a/Sitio/AltaModificacionNoticias.aspx.cs
+++ b/Sitio/AltaModificacionNoticias.aspx.cs
@@ -34,13 +34,13 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
 
     private void CargarDDLSecciones()
     {
-        ddlSecciones.DataSource = new ServicioEF().ListarSecciones().ToList();
+        ddlSecciones.DataSource = new ServicioEFSoapClient().ListarSecciones().ToList();
         ddlSecciones.DataTextField = "Nombre";
         ddlSecciones.DataBind();
     }
     private void CargarChkPeriodistas()
     {
-        chkPeriodistas.DataSource = new ServicioEF().ListarPeriodistas().ToList();
+        chkPeriodistas.DataSource = new ServicioEFSoapClient().ListarPeriodistas().ToList();
         chkPeriodistas.DataValueField = "Cedula";
         chkPeriodistas.DataTextField = "Nombre";
         chkPeriodistas.DataBind();
@@ -75,7 +75,7 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
             if (txtCodigo.Text.Length == 0)
                 throw new Exception("El codigo de la noticia no puede ser vacio.");
 
-            Noticias _unaNoticia = new ServicioEF().BuscarNoticia(txtCodigo.Text.Trim());
+            Noticias _unaNoticia = new ServicioEFSoapClient().BuscarNoticia(txtCodigo.Text.Trim());
 
             if (_unaNoticia == null)
             {
@@ -151,7 +151,7 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
             _unaN.FechaPublicacion = Convert.ToDateTime(txtFecha);
             
 
-            new ServicioEF().ModificarNoticia(_unaN);
+            new ServicioEFSoapClient().ModificarNoticia(_unaN);
 
             lblMensaje.Text = "Modificación con Exito";
 
@@ -182,7 +182,7 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
         {
             if(item.Selected)
             {
-                lista.Add(new ServicioEF().BuscarPeriodista(chkPeriodistas.SelectedItem.Value.ToString()));
+                lista.Add(new ServicioEFSoapClient().BuscarPeriodista(chkPeriodistas.SelectedItem.Value.ToString()));
             }
         }
 
@@ -196,8 +196,8 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
                 FechaPublicacion = Convert.ToDateTime(txtFecha.Text.Trim()),
                 Importancia = Convert.ToInt32(ddlImportancia.SelectedItem.Value),
                 Empleados = (Empleados)Session["usuarioLogueado"],
-                Secciones = new ServicioEF().BuscarSeccion(ddlSecciones.SelectedItem.Value),
-                Periodistas = lista
+                Secciones = new ServicioEFSoapClient().BuscarSeccion(ddlSecciones.SelectedItem.Value),
+                Periodistas = lista.ToArray<Periodistas>()
             };
         }
         catch (Exception ex)
@@ -208,7 +208,7 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
 
         try
         {
-            new ServicioEF().AltaNoticia(N);
+            new ServicioEFSoapClient().AltaNoticia(N);
 
             lblMensaje.Text = "Alta con Exito";
 

--- a/Sitio/App_Data/PublishProfiles/Sitio.pubxml
+++ b/Sitio/App_Data/PublishProfiles/Sitio.pubxml
@@ -6,7 +6,7 @@ editando este archivo MSBuild. Para conocer más acerca de esto, visite http://g
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <WebPublishMethod>FileSystem</WebPublishMethod>
-    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedBuildConfiguration>Debug</LastUsedBuildConfiguration>
     <LastUsedPlatform>Any CPU</LastUsedPlatform>
     <SiteUrlToLaunchAfterPublish />
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>

--- a/Sitio/App_WebReferences/RefServicio/Reference.svcmap
+++ b/Sitio/App_WebReferences/RefServicio/Reference.svcmap
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ReferenceGroup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="5aec847f-0d92-46eb-a2d8-d8cd8c38b061" xmlns="urn:schemas-microsoft-com:xml-wcfservicemap">
+  <ClientOptions>
+    <GenerateAsynchronousMethods>false</GenerateAsynchronousMethods>
+    <GenerateTaskBasedAsynchronousMethod>true</GenerateTaskBasedAsynchronousMethod>
+    <EnableDataBinding>true</EnableDataBinding>
+    <ExcludedTypes />
+    <ImportXmlTypes>false</ImportXmlTypes>
+    <GenerateInternalTypes>false</GenerateInternalTypes>
+    <GenerateMessageContracts>false</GenerateMessageContracts>
+    <NamespaceMappings />
+    <CollectionMappings />
+    <GenerateSerializableTypes>true</GenerateSerializableTypes>
+    <Serializer>Auto</Serializer>
+    <UseSerializerForFaults>true</UseSerializerForFaults>
+    <ReferenceAllAssemblies>true</ReferenceAllAssemblies>
+    <ReferencedAssemblies />
+    <ReferencedDataContractTypes />
+    <ServiceContractMappings />
+  </ClientOptions>
+  <MetadataSources>
+    <MetadataSource Address="http://localhost/obligatorio2/ServicioEF.asmx" Protocol="http" SourceId="1" />
+  </MetadataSources>
+  <Metadata>
+    <MetadataFile FileName="ServicioEF.disco" MetadataType="Disco" ID="ea1d2f26-11fb-4036-884f-12d060259dfa" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?disco" />
+    <MetadataFile FileName="ServicioEF.wsdl" MetadataType="Wsdl" ID="5e4aa567-6228-409f-a33c-8faeb9386b4d" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?wsdl" />
+  </Metadata>
+  <Extensions>
+    <ExtensionFile FileName="configuration91.svcinfo" Name="configuration91.svcinfo" />
+    <ExtensionFile FileName="configuration.svcinfo" Name="configuration.svcinfo" />
+  </Extensions>
+</ReferenceGroup>

--- a/Sitio/App_WebReferences/RefServicio/Reference.svcmap
+++ b/Sitio/App_WebReferences/RefServicio/Reference.svcmap
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ReferenceGroup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="5aec847f-0d92-46eb-a2d8-d8cd8c38b061" xmlns="urn:schemas-microsoft-com:xml-wcfservicemap">
+<ReferenceGroup xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" ID="8baf9402-cd86-406b-b21c-4126661aa4d2" xmlns="urn:schemas-microsoft-com:xml-wcfservicemap">
   <ClientOptions>
     <GenerateAsynchronousMethods>false</GenerateAsynchronousMethods>
     <GenerateTaskBasedAsynchronousMethod>true</GenerateTaskBasedAsynchronousMethod>
@@ -22,8 +22,8 @@
     <MetadataSource Address="http://localhost/obligatorio2/ServicioEF.asmx" Protocol="http" SourceId="1" />
   </MetadataSources>
   <Metadata>
-    <MetadataFile FileName="ServicioEF.disco" MetadataType="Disco" ID="ea1d2f26-11fb-4036-884f-12d060259dfa" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?disco" />
-    <MetadataFile FileName="ServicioEF.wsdl" MetadataType="Wsdl" ID="5e4aa567-6228-409f-a33c-8faeb9386b4d" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?wsdl" />
+    <MetadataFile FileName="ServicioEF.disco" MetadataType="Disco" ID="7c9faa1b-80dd-4340-92c3-c0d62503acfa" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?disco" />
+    <MetadataFile FileName="ServicioEF.wsdl" MetadataType="Wsdl" ID="164dea68-4cc7-4ad6-8aa0-430e16e82576" SourceId="1" SourceUrl="http://localhost/obligatorio2/ServicioEF.asmx?wsdl" />
   </Metadata>
   <Extensions>
     <ExtensionFile FileName="configuration91.svcinfo" Name="configuration91.svcinfo" />

--- a/Sitio/App_WebReferences/RefServicio/ServicioEF.disco
+++ b/Sitio/App_WebReferences/RefServicio/ServicioEF.disco
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <discovery xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://schemas.xmlsoap.org/disco/">
-  <contractRef ref="http://localhost/Servicio/ServicioEF.asmx?wsdl" docRef="http://localhost/Servicio/ServicioEF.asmx" xmlns="http://schemas.xmlsoap.org/disco/scl/" />
-  <soap address="http://localhost/Servicio/ServicioEF.asmx" xmlns:q1="http://tempuri.org/" binding="q1:ServicioEFSoap" xmlns="http://schemas.xmlsoap.org/disco/soap/" />
-  <soap address="http://localhost/Servicio/ServicioEF.asmx" xmlns:q2="http://tempuri.org/" binding="q2:ServicioEFSoap12" xmlns="http://schemas.xmlsoap.org/disco/soap/" />
+  <contractRef ref="http://localhost/obligatorio2/ServicioEF.asmx?wsdl" docRef="http://localhost/obligatorio2/ServicioEF.asmx" xmlns="http://schemas.xmlsoap.org/disco/scl/" />
+  <soap address="http://localhost/obligatorio2/ServicioEF.asmx" xmlns:q1="http://tempuri.org/" binding="q1:ServicioEFSoap" xmlns="http://schemas.xmlsoap.org/disco/soap/" />
+  <soap address="http://localhost/obligatorio2/ServicioEF.asmx" xmlns:q2="http://tempuri.org/" binding="q2:ServicioEFSoap12" xmlns="http://schemas.xmlsoap.org/disco/soap/" />
 </discovery>

--- a/Sitio/App_WebReferences/RefServicio/ServicioEF.discomap
+++ b/Sitio/App_WebReferences/RefServicio/ServicioEF.discomap
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<DiscoveryClientResultsFile xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <Results>
-    <DiscoveryClientResult referenceType="System.Web.Services.Discovery.DiscoveryDocumentReference" url="http://localhost/Servicio/ServicioEF.asmx?disco" filename="ServicioEF.disco" />
-    <DiscoveryClientResult referenceType="System.Web.Services.Discovery.ContractReference" url="http://localhost/Servicio/ServicioEF.asmx?wsdl" filename="ServicioEF.wsdl" />
-  </Results>
-</DiscoveryClientResultsFile>

--- a/Sitio/App_WebReferences/RefServicio/ServicioEF.wsdl
+++ b/Sitio/App_WebReferences/RefServicio/ServicioEF.wsdl
@@ -21,48 +21,6 @@
         <s:sequence>
           <s:element minOccurs="0" maxOccurs="1" name="NombreUsuario" type="s:string" />
           <s:element minOccurs="0" maxOccurs="1" name="Contraseña" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Noticias" type="tns:ArrayOfNoticias" />
-        </s:sequence>
-      </s:complexType>
-      <s:complexType name="ArrayOfNoticias">
-        <s:sequence>
-          <s:element minOccurs="0" maxOccurs="unbounded" name="Noticias" nillable="true" type="tns:Noticias" />
-        </s:sequence>
-      </s:complexType>
-      <s:complexType name="Noticias">
-        <s:sequence>
-          <s:element minOccurs="0" maxOccurs="1" name="Codigo" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="NombreUsuario" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="CodigoSeccion" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Titulo" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Cuerpo" type="s:string" />
-          <s:element minOccurs="1" maxOccurs="1" name="Importancia" type="s:int" />
-          <s:element minOccurs="1" maxOccurs="1" name="FechaPublicacion" type="s:dateTime" />
-          <s:element minOccurs="0" maxOccurs="1" name="Empleados" type="tns:Empleados" />
-          <s:element minOccurs="0" maxOccurs="1" name="Secciones" type="tns:Secciones" />
-          <s:element minOccurs="0" maxOccurs="1" name="Periodistas" type="tns:ArrayOfPeriodistas" />
-        </s:sequence>
-      </s:complexType>
-      <s:complexType name="Secciones">
-        <s:sequence>
-          <s:element minOccurs="0" maxOccurs="1" name="CodigoSeccion" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Nombre" type="s:string" />
-          <s:element minOccurs="1" maxOccurs="1" name="Activo" type="s:boolean" />
-          <s:element minOccurs="0" maxOccurs="1" name="Noticias" type="tns:ArrayOfNoticias" />
-        </s:sequence>
-      </s:complexType>
-      <s:complexType name="ArrayOfPeriodistas">
-        <s:sequence>
-          <s:element minOccurs="0" maxOccurs="unbounded" name="Periodistas" nillable="true" type="tns:Periodistas" />
-        </s:sequence>
-      </s:complexType>
-      <s:complexType name="Periodistas">
-        <s:sequence>
-          <s:element minOccurs="0" maxOccurs="1" name="Cedula" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Nombre" type="s:string" />
-          <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string" />
-          <s:element minOccurs="1" maxOccurs="1" name="Activo" type="s:boolean" />
-          <s:element minOccurs="0" maxOccurs="1" name="Noticias" type="tns:ArrayOfNoticias" />
         </s:sequence>
       </s:complexType>
       <s:element name="AltaEmpleado">
@@ -89,6 +47,14 @@
           </s:sequence>
         </s:complexType>
       </s:element>
+      <s:complexType name="Periodistas">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Cedula" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Nombre" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Email" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Activo" type="s:boolean" />
+        </s:sequence>
+      </s:complexType>
       <s:element name="AltaPeriodista">
         <s:complexType>
           <s:sequence>
@@ -129,6 +95,11 @@
           </s:sequence>
         </s:complexType>
       </s:element>
+      <s:complexType name="ArrayOfPeriodistas">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Periodistas" nillable="true" type="tns:Periodistas" />
+        </s:sequence>
+      </s:complexType>
       <s:element name="BuscarSeccion">
         <s:complexType>
           <s:sequence>
@@ -143,6 +114,13 @@
           </s:sequence>
         </s:complexType>
       </s:element>
+      <s:complexType name="Secciones">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="CodigoSeccion" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Nombre" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Activo" type="s:boolean" />
+        </s:sequence>
+      </s:complexType>
       <s:element name="AltaSeccion">
         <s:complexType>
           <s:sequence>
@@ -202,6 +180,20 @@
           </s:sequence>
         </s:complexType>
       </s:element>
+      <s:complexType name="Noticias">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="1" name="Codigo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="NombreUsuario" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="CodigoSeccion" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Titulo" type="s:string" />
+          <s:element minOccurs="0" maxOccurs="1" name="Cuerpo" type="s:string" />
+          <s:element minOccurs="1" maxOccurs="1" name="Importancia" type="s:int" />
+          <s:element minOccurs="1" maxOccurs="1" name="FechaPublicacion" type="s:dateTime" />
+          <s:element minOccurs="0" maxOccurs="1" name="Empleados" type="tns:Empleados" />
+          <s:element minOccurs="0" maxOccurs="1" name="Secciones" type="tns:Secciones" />
+          <s:element minOccurs="0" maxOccurs="1" name="Periodistas" type="tns:ArrayOfPeriodistas" />
+        </s:sequence>
+      </s:complexType>
       <s:element name="ModificarNoticia">
         <s:complexType>
           <s:sequence>
@@ -232,6 +224,11 @@
           </s:sequence>
         </s:complexType>
       </s:element>
+      <s:complexType name="ArrayOfNoticias">
+        <s:sequence>
+          <s:element minOccurs="0" maxOccurs="unbounded" name="Noticias" nillable="true" type="tns:Noticias" />
+        </s:sequence>
+      </s:complexType>
     </s:schema>
   </wsdl:types>
   <wsdl:message name="LogueoSoapIn">

--- a/Sitio/App_WebReferences/RefServicio/ServicioEF.wsdl
+++ b/Sitio/App_WebReferences/RefServicio/ServicioEF.wsdl
@@ -222,6 +222,16 @@
       <s:element name="AltaNoticiaResponse">
         <s:complexType />
       </s:element>
+      <s:element name="MostrarNoticiasUltimosCincoDias">
+        <s:complexType />
+      </s:element>
+      <s:element name="MostrarNoticiasUltimosCincoDiasResponse">
+        <s:complexType>
+          <s:sequence>
+            <s:element minOccurs="0" maxOccurs="1" name="MostrarNoticiasUltimosCincoDiasResult" type="tns:ArrayOfNoticias" />
+          </s:sequence>
+        </s:complexType>
+      </s:element>
     </s:schema>
   </wsdl:types>
   <wsdl:message name="LogueoSoapIn">
@@ -314,6 +324,12 @@
   <wsdl:message name="AltaNoticiaSoapOut">
     <wsdl:part name="parameters" element="tns:AltaNoticiaResponse" />
   </wsdl:message>
+  <wsdl:message name="MostrarNoticiasUltimosCincoDiasSoapIn">
+    <wsdl:part name="parameters" element="tns:MostrarNoticiasUltimosCincoDias" />
+  </wsdl:message>
+  <wsdl:message name="MostrarNoticiasUltimosCincoDiasSoapOut">
+    <wsdl:part name="parameters" element="tns:MostrarNoticiasUltimosCincoDiasResponse" />
+  </wsdl:message>
   <wsdl:portType name="ServicioEFSoap">
     <wsdl:operation name="Logueo">
       <wsdl:input message="tns:LogueoSoapIn" />
@@ -374,6 +390,10 @@
     <wsdl:operation name="AltaNoticia">
       <wsdl:input message="tns:AltaNoticiaSoapIn" />
       <wsdl:output message="tns:AltaNoticiaSoapOut" />
+    </wsdl:operation>
+    <wsdl:operation name="MostrarNoticiasUltimosCincoDias">
+      <wsdl:input message="tns:MostrarNoticiasUltimosCincoDiasSoapIn" />
+      <wsdl:output message="tns:MostrarNoticiasUltimosCincoDiasSoapOut" />
     </wsdl:operation>
   </wsdl:portType>
   <wsdl:binding name="ServicioEFSoap" type="tns:ServicioEFSoap">
@@ -506,6 +526,15 @@
     </wsdl:operation>
     <wsdl:operation name="AltaNoticia">
       <soap:operation soapAction="http://tempuri.org/AltaNoticia" style="document" />
+      <wsdl:input>
+        <soap:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
+    <wsdl:operation name="MostrarNoticiasUltimosCincoDias">
+      <soap:operation soapAction="http://tempuri.org/MostrarNoticiasUltimosCincoDias" style="document" />
       <wsdl:input>
         <soap:body use="literal" />
       </wsdl:input>
@@ -651,13 +680,22 @@
         <soap12:body use="literal" />
       </wsdl:output>
     </wsdl:operation>
+    <wsdl:operation name="MostrarNoticiasUltimosCincoDias">
+      <soap12:operation soapAction="http://tempuri.org/MostrarNoticiasUltimosCincoDias" style="document" />
+      <wsdl:input>
+        <soap12:body use="literal" />
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal" />
+      </wsdl:output>
+    </wsdl:operation>
   </wsdl:binding>
   <wsdl:service name="ServicioEF">
     <wsdl:port name="ServicioEFSoap" binding="tns:ServicioEFSoap">
-      <soap:address location="http://localhost/Servicio/ServicioEF.asmx" />
+      <soap:address location="http://localhost/obligatorio2/ServicioEF.asmx" />
     </wsdl:port>
     <wsdl:port name="ServicioEFSoap12" binding="tns:ServicioEFSoap12">
-      <soap12:address location="http://localhost/Servicio/ServicioEF.asmx" />
+      <soap12:address location="http://localhost/obligatorio2/ServicioEF.asmx" />
     </wsdl:port>
   </wsdl:service>
 </wsdl:definitions>

--- a/Sitio/App_WebReferences/RefServicio/configuration.svcinfo
+++ b/Sitio/App_WebReferences/RefServicio/configuration.svcinfo
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configurationSnapshot xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="urn:schemas-microsoft-com:xml-wcfconfigurationsnapshot">
+  <behaviors />
+  <bindings>
+    <binding digest="System.ServiceModel.Configuration.BasicHttpBindingElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089:&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&lt;Data name=&quot;ServicioEFSoap&quot; /&gt;" bindingType="basicHttpBinding" name="ServicioEFSoap" />
+  </bindings>
+  <endpoints>
+    <endpoint normalizedDigest="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&lt;Data address=&quot;http://localhost/obligatorio2/ServicioEF.asmx&quot; binding=&quot;basicHttpBinding&quot; bindingConfiguration=&quot;ServicioEFSoap&quot; contract=&quot;RefServicio.ServicioEFSoap&quot; name=&quot;ServicioEFSoap&quot; /&gt;" digest="&lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-16&quot;?&gt;&lt;Data address=&quot;http://localhost/obligatorio2/ServicioEF.asmx&quot; binding=&quot;basicHttpBinding&quot; bindingConfiguration=&quot;ServicioEFSoap&quot; contract=&quot;RefServicio.ServicioEFSoap&quot; name=&quot;ServicioEFSoap&quot; /&gt;" contractName="RefServicio.ServicioEFSoap" name="ServicioEFSoap" />
+  </endpoints>
+</configurationSnapshot>

--- a/Sitio/App_WebReferences/RefServicio/configuration91.svcinfo
+++ b/Sitio/App_WebReferences/RefServicio/configuration91.svcinfo
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<SavedWcfConfigurationInformation xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Version="9.1" CheckSum="IFCmiAHy2XV7xxdcVedQasexWYuaNCXPKRe/jTUIRmU=">
+  <bindingConfigurations>
+    <bindingConfiguration bindingType="basicHttpBinding" name="ServicioEFSoap">
+      <properties>
+        <property path="/name" isComplexType="false" isExplicitlyDefined="true" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>ServicioEFSoap</serializedValue>
+        </property>
+        <property path="/closeTimeout" isComplexType="false" isExplicitlyDefined="true" clrType="System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/openTimeout" isComplexType="false" isExplicitlyDefined="true" clrType="System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/receiveTimeout" isComplexType="false" isExplicitlyDefined="true" clrType="System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/sendTimeout" isComplexType="false" isExplicitlyDefined="true" clrType="System.TimeSpan, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/allowCookies" isComplexType="false" isExplicitlyDefined="true" clrType="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/bypassProxyOnLocal" isComplexType="false" isExplicitlyDefined="true" clrType="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/hostNameComparisonMode" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.HostNameComparisonMode, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>StrongWildcard</serializedValue>
+        </property>
+        <property path="/maxBufferPoolSize" isComplexType="false" isExplicitlyDefined="true" clrType="System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/maxBufferSize" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>65536</serializedValue>
+        </property>
+        <property path="/maxReceivedMessageSize" isComplexType="false" isExplicitlyDefined="true" clrType="System.Int64, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/proxyAddress" isComplexType="false" isExplicitlyDefined="false" clrType="System.Uri, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/readerQuotas" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.XmlDictionaryReaderQuotasElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.XmlDictionaryReaderQuotasElement</serializedValue>
+        </property>
+        <property path="/readerQuotas/maxDepth" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>0</serializedValue>
+        </property>
+        <property path="/readerQuotas/maxStringContentLength" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>0</serializedValue>
+        </property>
+        <property path="/readerQuotas/maxArrayLength" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>0</serializedValue>
+        </property>
+        <property path="/readerQuotas/maxBytesPerRead" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>0</serializedValue>
+        </property>
+        <property path="/readerQuotas/maxNameTableCharCount" isComplexType="false" isExplicitlyDefined="false" clrType="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>0</serializedValue>
+        </property>
+        <property path="/textEncoding" isComplexType="false" isExplicitlyDefined="false" clrType="System.Text.Encoding, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.Text.UTF8Encoding</serializedValue>
+        </property>
+        <property path="/transferMode" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.TransferMode, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>Buffered</serializedValue>
+        </property>
+        <property path="/useDefaultWebProxy" isComplexType="false" isExplicitlyDefined="true" clrType="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/messageEncoding" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.WSMessageEncoding, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>Text</serializedValue>
+        </property>
+        <property path="/security" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.BasicHttpSecurityElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.BasicHttpSecurityElement</serializedValue>
+        </property>
+        <property path="/security/mode" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.BasicHttpSecurityMode, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>None</serializedValue>
+        </property>
+        <property path="/security/transport" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.HttpTransportSecurityElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.HttpTransportSecurityElement</serializedValue>
+        </property>
+        <property path="/security/transport/clientCredentialType" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.HttpClientCredentialType, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>None</serializedValue>
+        </property>
+        <property path="/security/transport/proxyCredentialType" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.HttpProxyCredentialType, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>None</serializedValue>
+        </property>
+        <property path="/security/transport/extendedProtectionPolicy" isComplexType="true" isExplicitlyDefined="false" clrType="System.Security.Authentication.ExtendedProtection.Configuration.ExtendedProtectionPolicyElement, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.Security.Authentication.ExtendedProtection.Configuration.ExtendedProtectionPolicyElement</serializedValue>
+        </property>
+        <property path="/security/transport/extendedProtectionPolicy/policyEnforcement" isComplexType="false" isExplicitlyDefined="false" clrType="System.Security.Authentication.ExtendedProtection.PolicyEnforcement, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>Never</serializedValue>
+        </property>
+        <property path="/security/transport/extendedProtectionPolicy/protectionScenario" isComplexType="false" isExplicitlyDefined="false" clrType="System.Security.Authentication.ExtendedProtection.ProtectionScenario, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>TransportSelected</serializedValue>
+        </property>
+        <property path="/security/transport/extendedProtectionPolicy/customServiceNames" isComplexType="true" isExplicitlyDefined="false" clrType="System.Security.Authentication.ExtendedProtection.Configuration.ServiceNameElementCollection, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>(Colección)</serializedValue>
+        </property>
+        <property path="/security/transport/realm" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/security/message" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.BasicHttpMessageSecurityElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.BasicHttpMessageSecurityElement</serializedValue>
+        </property>
+        <property path="/security/message/clientCredentialType" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.BasicHttpMessageCredentialType, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>UserName</serializedValue>
+        </property>
+        <property path="/security/message/algorithmSuite" isComplexType="false" isExplicitlyDefined="false" clrType="System.ServiceModel.Security.SecurityAlgorithmSuite, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>Default</serializedValue>
+        </property>
+      </properties>
+    </bindingConfiguration>
+  </bindingConfigurations>
+  <endpoints>
+    <endpoint name="ServicioEFSoap" contract="RefServicio.ServicioEFSoap" bindingType="basicHttpBinding" address="http://localhost/obligatorio2/ServicioEF.asmx" bindingConfiguration="ServicioEFSoap">
+      <properties>
+        <property path="/address" isComplexType="false" isExplicitlyDefined="true" clrType="System.Uri, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>http://localhost/obligatorio2/ServicioEF.asmx</serializedValue>
+        </property>
+        <property path="/behaviorConfiguration" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/binding" isComplexType="false" isExplicitlyDefined="true" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>basicHttpBinding</serializedValue>
+        </property>
+        <property path="/bindingConfiguration" isComplexType="false" isExplicitlyDefined="true" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>ServicioEFSoap</serializedValue>
+        </property>
+        <property path="/contract" isComplexType="false" isExplicitlyDefined="true" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>RefServicio.ServicioEFSoap</serializedValue>
+        </property>
+        <property path="/headers" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.AddressHeaderCollectionElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.AddressHeaderCollectionElement</serializedValue>
+        </property>
+        <property path="/headers/headers" isComplexType="false" isExplicitlyDefined="true" clrType="System.ServiceModel.Channels.AddressHeaderCollection, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>&lt;Header /&gt;</serializedValue>
+        </property>
+        <property path="/identity" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.IdentityElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.IdentityElement</serializedValue>
+        </property>
+        <property path="/identity/userPrincipalName" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.UserPrincipalNameElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.UserPrincipalNameElement</serializedValue>
+        </property>
+        <property path="/identity/userPrincipalName/value" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/servicePrincipalName" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.ServicePrincipalNameElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.ServicePrincipalNameElement</serializedValue>
+        </property>
+        <property path="/identity/servicePrincipalName/value" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/dns" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.DnsElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.DnsElement</serializedValue>
+        </property>
+        <property path="/identity/dns/value" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/rsa" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.RsaElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.RsaElement</serializedValue>
+        </property>
+        <property path="/identity/rsa/value" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/certificate" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.CertificateElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.CertificateElement</serializedValue>
+        </property>
+        <property path="/identity/certificate/encodedValue" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/certificateReference" isComplexType="true" isExplicitlyDefined="false" clrType="System.ServiceModel.Configuration.CertificateReferenceElement, System.ServiceModel, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>System.ServiceModel.Configuration.CertificateReferenceElement</serializedValue>
+        </property>
+        <property path="/identity/certificateReference/storeName" isComplexType="false" isExplicitlyDefined="false" clrType="System.Security.Cryptography.X509Certificates.StoreName, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>My</serializedValue>
+        </property>
+        <property path="/identity/certificateReference/storeLocation" isComplexType="false" isExplicitlyDefined="false" clrType="System.Security.Cryptography.X509Certificates.StoreLocation, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>LocalMachine</serializedValue>
+        </property>
+        <property path="/identity/certificateReference/x509FindType" isComplexType="false" isExplicitlyDefined="false" clrType="System.Security.Cryptography.X509Certificates.X509FindType, System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>FindBySubjectDistinguishedName</serializedValue>
+        </property>
+        <property path="/identity/certificateReference/findValue" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/identity/certificateReference/isChainIncluded" isComplexType="false" isExplicitlyDefined="false" clrType="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>False</serializedValue>
+        </property>
+        <property path="/name" isComplexType="false" isExplicitlyDefined="true" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue>ServicioEFSoap</serializedValue>
+        </property>
+        <property path="/kind" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+        <property path="/endpointConfiguration" isComplexType="false" isExplicitlyDefined="false" clrType="System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+          <serializedValue />
+        </property>
+      </properties>
+    </endpoint>
+  </endpoints>
+</SavedWcfConfigurationInformation>

--- a/Sitio/ConsultaNoticia.aspx
+++ b/Sitio/ConsultaNoticia.aspx
@@ -5,12 +5,66 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head runat="server">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title></title>
+    <title>Consulta de noticia</title>
 </head>
+    <style>
+        div {
+            margin: 0 0 2em 2em;
+        }
+        .label-container {
+            text-align: right;
+        }
+    </style>
 <body>
     <form id="form1" runat="server">
         <div>
+            <asp:HyperLink ID="HyperLink1" runat="server" NavigateUrl="~/Default.aspx">Volver</asp:HyperLink>
         </div>
+        <table style="width: 100%;">
+            <tr>
+                <td class="label-container"><label>Código: </label></td>
+                <td>
+                    <asp:TextBox ID="TxtCodigo" runat="server"></asp:TextBox>
+                </td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>Sección:</label>
+                </td>
+                <td><asp:TextBox ID="TxtSeccion" runat="server"></asp:TextBox></td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>Título: </label>
+                </td>
+                <td><asp:TextBox ID="TxtTitulo" runat="server"></asp:TextBox></td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>Cuerpo: </label>
+                </td>
+                <td><asp:TextBox ID="TxtCuerpo" runat="server"></asp:TextBox></td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>Importancia: </label>
+                </td>
+                <td><asp:TextBox ID="TxtImportancia" runat="server"></asp:TextBox></td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>FechaPublicación: </label>
+                </td>
+                <td><asp:TextBox ID="TxtFecha" runat="server"></asp:TextBox></td>
+            </tr>
+            <tr>
+                <td class="label-container">
+                    <label>Periodistas: </label>
+                </td>
+                <td>
+                    <asp:ListBox ID="LstPeriodistas" runat="server"></asp:ListBox></td>
+            </tr>
+        </table>
     </form>
 </body>
 </html>

--- a/Sitio/ConsultaNoticia.aspx
+++ b/Sitio/ConsultaNoticia.aspx
@@ -1,0 +1,16 @@
+﻿<%@ Page Language="C#" AutoEventWireup="true" CodeFile="ConsultaNoticia.aspx.cs" Inherits="ConsultaNoticia" %>
+
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head runat="server">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title></title>
+</head>
+<body>
+    <form id="form1" runat="server">
+        <div>
+        </div>
+    </form>
+</body>
+</html>

--- a/Sitio/ConsultaNoticia.aspx
+++ b/Sitio/ConsultaNoticia.aspx
@@ -24,38 +24,38 @@
             <tr>
                 <td class="label-container"><label>Código: </label></td>
                 <td>
-                    <asp:TextBox ID="TxtCodigo" runat="server"></asp:TextBox>
+                    <asp:TextBox ID="TxtCodigo" runat="server" ReadOnly="True"></asp:TextBox>
                 </td>
             </tr>
             <tr>
                 <td class="label-container">
                     <label>Sección:</label>
                 </td>
-                <td><asp:TextBox ID="TxtSeccion" runat="server"></asp:TextBox></td>
+                <td><asp:TextBox ID="TxtSeccion" runat="server" ReadOnly="True"></asp:TextBox></td>
             </tr>
             <tr>
                 <td class="label-container">
                     <label>Título: </label>
                 </td>
-                <td><asp:TextBox ID="TxtTitulo" runat="server"></asp:TextBox></td>
+                <td><asp:TextBox ID="TxtTitulo" runat="server" ReadOnly="True"></asp:TextBox></td>
             </tr>
             <tr>
                 <td class="label-container">
                     <label>Cuerpo: </label>
                 </td>
-                <td><asp:TextBox ID="TxtCuerpo" runat="server"></asp:TextBox></td>
+                <td><asp:TextBox ID="TxtCuerpo" runat="server" ReadOnly="True"></asp:TextBox></td>
             </tr>
             <tr>
                 <td class="label-container">
                     <label>Importancia: </label>
                 </td>
-                <td><asp:TextBox ID="TxtImportancia" runat="server"></asp:TextBox></td>
+                <td><asp:TextBox ID="TxtImportancia" runat="server" ReadOnly="True"></asp:TextBox></td>
             </tr>
             <tr>
                 <td class="label-container">
                     <label>FechaPublicación: </label>
                 </td>
-                <td><asp:TextBox ID="TxtFecha" runat="server"></asp:TextBox></td>
+                <td><asp:TextBox ID="TxtFecha" runat="server" ReadOnly="True"></asp:TextBox></td>
             </tr>
             <tr>
                 <td class="label-container">
@@ -65,6 +65,7 @@
                     <asp:ListBox ID="LstPeriodistas" runat="server"></asp:ListBox></td>
             </tr>
         </table>
+        <asp:Label ID="lblMensaje" runat="server" Text=""></asp:Label>
     </form>
 </body>
 </html>

--- a/Sitio/ConsultaNoticia.aspx.cs
+++ b/Sitio/ConsultaNoticia.aspx.cs
@@ -4,11 +4,33 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using System.Web.Services.Protocols;
+using RefServicio;
 
 public partial class ConsultaNoticia : System.Web.UI.Page
 {
     protected void Page_Load(object sender, EventArgs e)
     {
+        try
+        {
+            Noticias noticia = (Noticias)Session["noticiaSeleccionada"];
 
+            TxtCodigo.Text = noticia.Codigo;
+            TxtTitulo.Text = noticia.Titulo;
+            TxtCuerpo.Text = noticia.Cuerpo;
+            TxtFecha.Text = noticia.FechaPublicacion.ToShortDateString();
+            TxtImportancia.Text = noticia.Importancia.ToString();
+            TxtSeccion.Text = noticia.Secciones.Nombre;
+
+            foreach (Periodistas periodista in noticia.Periodistas)
+            {
+                LstPeriodistas.Items.Add(periodista.Nombre);
+            }
+
+        }
+        catch (Exception ex)
+        {
+            lblMensaje.Text = ex.Message;
+        }
     }
 }

--- a/Sitio/ConsultaNoticia.aspx.cs
+++ b/Sitio/ConsultaNoticia.aspx.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+
+public partial class ConsultaNoticia : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+
+    }
+}

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -1,0 +1,17 @@
+﻿<%@ Page Language="C#" AutoEventWireup="true" CodeFile="Default.aspx.cs" Inherits="_Default" %>
+
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head runat="server">
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+    <title></title>
+</head>
+<body>
+    <form id="form1" runat="server">
+        <div>
+            <asp:GridView ID="grdNoticias" runat="server"></asp:GridView>
+        </div>
+    </form>
+</body>
+</html>

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -10,7 +10,13 @@
 <body>
     <form id="form1" runat="server">
         <div>
-            <asp:GridView ID="grdNoticias" runat="server"></asp:GridView>
+            <asp:GridView ID="grdNoticias" runat="server" AutoGenerateColumns="False" OnSelectedIndexChanged="grdNoticias_SelectedIndexChanged">
+                <Columns>
+                    <asp:BoundField AccessibleHeaderText="Titulo" DataField="Titulo" HeaderText="Titulo" />
+                    <asp:BoundField AccessibleHeaderText="Fecha de publicación" DataField="FechaPublicacion" HeaderText="Fecha de publicación" />
+                    <asp:CommandField ShowSelectButton="True" />
+                </Columns>
+            </asp:GridView>
         </div>
     </form>
 </body>

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -18,6 +18,7 @@
                 </Columns>
             </asp:GridView>
         </div>
+        <asp:Label ID="lblMensaje" runat="server" Text=""></asp:Label>
     </form>
 </body>
 </html>

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -23,4 +23,9 @@ public partial class _Default : System.Web.UI.Page
             grdNoticias.DataBind();
         }
     }
+
+    protected void grdNoticias_SelectedIndexChanged(object sender, EventArgs e)
+    {
+
+    }
 }

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Web;
 using System.Web.UI;
 using System.Web.UI.WebControls;
+using System.Web.Services.Protocols;
 using RefServicio;
 
 
@@ -11,26 +12,48 @@ public partial class _Default : System.Web.UI.Page
 {
     protected void Page_Load(object sender, EventArgs e)
     {
-        if (!IsPostBack)
+        try
         {
-            ServicioEFSoapClient servicio = new ServicioEFSoapClient();
+            if (!IsPostBack)
+            {
+                ServicioEFSoapClient servicio = new ServicioEFSoapClient();
 
-            List<Noticias> noticias = servicio.MostrarNoticiasUltimosCincoDias().ToList<Noticias>();
+                List<Noticias> noticias = servicio.MostrarNoticiasUltimosCincoDias().ToList<Noticias>();
 
-            Session["noticias"] = noticias;
+                Session["noticias"] = noticias;
 
-            grdNoticias.DataSource = noticias;
-            grdNoticias.DataBind();
+                grdNoticias.DataSource = noticias;
+                grdNoticias.DataBind();
+            }
+        }
+        catch (SoapException ex)
+        {
+            lblMensaje.Text = ex.Detail.InnerText;
+        }
+        catch (Exception ex)
+        {
+            lblMensaje.Text = ex.Message;
         }
     }
 
     protected void grdNoticias_SelectedIndexChanged(object sender, EventArgs e)
     {
-        List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+        try
+        {
+            List<Noticias> noticias = (List<Noticias>)Session["noticias"];
 
-        Noticias noticiaSeleccionada = noticias[grdNoticias.SelectedIndex];
+            Noticias noticiaSeleccionada = noticias[grdNoticias.SelectedIndex];
 
-        Session["noticiaSeleccionada"] = noticiaSeleccionada;
-        Response.Redirect("~/ConsultaNoticia.aspx");
+            Session["noticiaSeleccionada"] = noticiaSeleccionada;
+            Response.Redirect("~/ConsultaNoticia.aspx");
+        }
+        catch (SoapException ex)
+        {
+            lblMensaje.Text = ex.Detail.InnerText;
+        }
+        catch (Exception ex)
+        {
+            lblMensaje.Text = ex.Message;
+        }
     }
 }

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -26,6 +26,11 @@ public partial class _Default : System.Web.UI.Page
 
     protected void grdNoticias_SelectedIndexChanged(object sender, EventArgs e)
     {
+        List<Noticias> noticias = (List<Noticias>)Session["noticias"];
 
+        Noticias noticiaSeleccionada = noticias[grdNoticias.SelectedIndex];
+
+        Session["noticiaSeleccionada"] = noticiaSeleccionada;
+        Response.Redirect("~/ConsultaNoticia.aspx");
     }
 }

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.UI;
+using System.Web.UI.WebControls;
+using RefServicio;
+
+
+public partial class _Default : System.Web.UI.Page
+{
+    protected void Page_Load(object sender, EventArgs e)
+    {
+        if (!IsPostBack)
+        {
+            ServicioEFSoapClient servicio = new ServicioEFSoapClient();
+
+            List<Noticias> noticias = servicio.MostrarNoticiasUltimosCincoDias().ToList<Noticias>();
+
+            Session["noticias"] = noticias;
+
+            grdNoticias.DataSource = noticias;
+            grdNoticias.DataBind();
+        }
+    }
+}

--- a/Sitio/Logueo.aspx.cs
+++ b/Sitio/Logueo.aspx.cs
@@ -18,7 +18,7 @@ public partial class Logueo : System.Web.UI.Page
     {
         try
         {
-            Empleados emp = new ServicioEF().Logueo(txtNombreUsuario.Text, txtContraseña.Text);
+            Empleados emp = new ServicioEFSoapClient().Logueo(txtNombreUsuario.Text, txtContraseña.Text);
 
             if (emp != null)
             {

--- a/Sitio/Web.config
+++ b/Sitio/Web.config
@@ -8,9 +8,7 @@
     \Windows\Microsoft.Net\Framework\vx.x\Config 
 -->
 <configuration>
-  <appSettings>
-  <add key="RefServicio.ServicioEF" value="http://localhost/Servicio/ServicioEF.asmx"/>
-  </appSettings>
+  <appSettings/>
   <connectionStrings/>
   <!--
     Para obtener una descripción de los cambios de web.config, vea http://go.microsoft.com/fwlink/?LinkId=235367.
@@ -53,7 +51,15 @@
         Information Services 7.0.  No es necesaria para la versión anterior de IIS.
   -->
   <system.serviceModel>
-    <bindings/>
-    <client/>
+    <bindings>
+      <basicHttpBinding>
+        <binding name="ServicioEFSoap" />
+      </basicHttpBinding>
+    </bindings>
+    <client>
+      <endpoint address="http://localhost/obligatorio2/ServicioEF.asmx"
+        binding="basicHttpBinding" bindingConfiguration="ServicioEFSoap"
+        contract="RefServicio.ServicioEFSoap" name="ServicioEFSoap" />
+    </client>
   </system.serviceModel>
 </configuration>


### PR DESCRIPTION
Acá se realiza la implementación de la funcionalidad de la página `Default.aspx`.

La complejidad de la tarea se encontraba en el modelo, porque en su versión anterior este tenía doble navegabilidad entre las diferentes entidades. Esto producía errores de referencia circular cuando la operación `LogicaModeloEF.MostrarNoticiasUltimosCincoDias` intentaba devolver las noticias al cliente. 

Ya que se devolvían las noticias sin los periodistas, el profesor recomendó el uso de la operación `Include`, tal como se explica en [la documentación oficial de Microsoft](https://docs.microsoft.com/en-us/ef/ef6/querying/related-data#eagerly-loading). Esta operación tiene como objetivo forzar la carga diligente, de manera que el objeto `Noticia` venga cargado con instancias de todas las clases asociadas.

Aparte, **se implementó de forma impropia** la página de `ConsultaNoticia.aspx`. El enunciado del ejercicio exige que esta página implemente un `UserControl`, pero usé temporalmente un formulario común para verificar fácilmente que el objeto `Noticia` contuviera todos los datos exigidos