### PR TITLE
Filtro seccion default

### DIFF
--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -10,6 +10,10 @@
 <body>
     <form id="form1" runat="server">
         <div>
+            <p style="display: inline;">Filtra las noticias por secciones usando este menú desplegable: </p>
+            <asp:DropDownList ID="ddlFiltroSeccion" runat="server" AutoPostBack="True"></asp:DropDownList>
+        </div>
+        <div>
             <asp:GridView ID="grdNoticias" runat="server" AutoGenerateColumns="False" OnSelectedIndexChanged="grdNoticias_SelectedIndexChanged">
                 <Columns>
                     <asp:BoundField AccessibleHeaderText="Titulo" DataField="Titulo" HeaderText="Titulo" />

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -11,7 +11,9 @@
     <form id="form1" runat="server">
         <div>
             <p style="display: inline;">Filtra las noticias por secciones usando este menú desplegable: </p>
-            <asp:DropDownList ID="ddlFiltroSeccion" runat="server" AutoPostBack="True"></asp:DropDownList>
+            <asp:DropDownList ID="ddlFiltroSeccion" runat="server" AutoPostBack="True" OnSelectedIndexChanged="ddlFiltroSeccion_SelectedIndexChanged">
+                <asp:ListItem Selected="True">Sin filtro</asp:ListItem>
+            </asp:DropDownList>
         </div>
         <div>
             <asp:GridView ID="grdNoticias" runat="server" AutoGenerateColumns="False" OnSelectedIndexChanged="grdNoticias_SelectedIndexChanged">


### PR DESCRIPTION
Esta es la implementación del primer filtro en la página `Default.aspx`. Se trata del filtro de noticias por sección.

La implementación incluye la carga dinámica del menú desplegable de secciones en el `Page_Load` de la página. 

También se implementó la capacidad que permite filtrar la grilla de noticias al seleccionar un elemento del menú desplegable de secciones.

Queda pendiente todavía la implementación del filtro por fecha y del filtro `Sin filtro`.