### PR TITLE
Corrección de LogicaModeloEF.ModificarNoticia

### DIFF
--- a/Base de Datos/Obligatorio.sql
+++ b/Base de Datos/Obligatorio.sql
@@ -356,7 +356,6 @@ EXEC AltaPeriodista '00000000', 'Periodista 5', 'period5@gmail.com'
 EXEC ModificarPeriodista '67839025', 'Periodista 6', 'period6@gmail.com'
 GO
 
-
 INSERT INTO Noticias(Codigo, Titulo, Cuerpo, Importancia, FechaPublicacion, CodigoSeccion, NombreUsuario)
 Values('codnot1', 'Titulo Noticia 1','Cuerpo Noticia 1', 4,'20211017', 'polic', 'Empleado10'),
 ('codnot2', 'Titulo Noticia 2','Cuerpo Noticia 2', 3,'20201013', 'econo', 'Empleado10'),
@@ -366,14 +365,18 @@ Values('codnot1', 'Titulo Noticia 1','Cuerpo Noticia 1', 4,'20211017', 'polic', 
 ('codnot6', 'Titulo Noticia 6','Cuerpo Noticia 6', 5,'20211029', 'econo', 'Empleado10'),
 ('codnot7', 'Titulo Noticia 7','Cuerpo Noticia 7', 2,'20210820', 'cultu', 'Empleado20'),
 ('codnot8', 'Titulo Noticia 8','Cuerpo Noticia 8', 2,'20210821', 'econo', 'Empleado30'),
-('codnot9', 'Titulo Noticia 9','Cuerpo Noticia 9', 5,'20211029', 'inter', 'Empleado10'),
-('codnot10', 'Titulo Noticia 10','Cuerpo Noticia 10', 3,'20191012', 'inter', 'Empleado40'),
-('codnot11', 'Titulo Noticia 11','Cuerpo Noticia 11', 4,'20211029', 'inter', 'Empleado20'),
-('codnot12', 'Titulo Noticia 12','Cuerpo Noticia 12', 3,'20191012', 'inter', 'Empleado40'),
-('codnot13', 'Titulo Noticia 13','Cuerpo Noticia 13', 1,'20210809', 'inter', 'Empleado30'),
-('codnot14', 'Titulo Noticia 14','Cuerpo Noticia 14', 3,'20211104', 'inter', 'Empleado20'),
-('codnot15', 'Titulo Noticia 15','Cuerpo Noticia 15', 3,'20211105', 'inter', 'Empleado20'),
-('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,'20211106', 'inter', 'Empleado40')
+('codnot9', 'Titulo Noticia 9','Cuerpo Noticia 9', 5,'20211029', 'inter', 'Empleado10')
+GO 
+
+-- para actualizar automáticamente las fechas de las noticias a mostrar
+INSERT INTO Noticias(Codigo, Titulo, Cuerpo, Importancia, FechaPublicacion, CodigoSeccion, NombreUsuario)
+Values ('codnot10', 'Titulo Noticia 10','Cuerpo Noticia 10', 3,DATEADD(DAY, -5, GETDATE()), 'inter', 'Empleado40'),
+('codnot11', 'Titulo Noticia 11','Cuerpo Noticia 11', 4,DATEADD(DAY, -5, GETDATE()), 'inter', 'Empleado20'),
+('codnot12', 'Titulo Noticia 12','Cuerpo Noticia 12', 3,DATEADD(DAY, -3, GETDATE()), 'inter', 'Empleado10'),
+('codnot13', 'Titulo Noticia 13','Cuerpo Noticia 13', 1,DATEADD(DAY, -1, GETDATE()), 'inter', 'Empleado30'),
+('codnot14', 'Titulo Noticia 14','Cuerpo Noticia 14', 3,DATEADD(DAY, -1, GETDATE()), 'inter', 'Empleado20'),
+('codnot15', 'Titulo Noticia 15','Cuerpo Noticia 15', 3,GETDATE(), 'inter', 'Empleado10'),
+('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,GETDATE(), 'inter', 'Empleado40')
 GO
 
 SELECT * FROM Empleados

--- a/Base de Datos/Obligatorio.sql
+++ b/Base de Datos/Obligatorio.sql
@@ -242,6 +242,30 @@ BEGIN
 END
 GO
 
+-- sp creado únicamente para satisfacer al Entity Framework
+-- y mapearlo en el modelo como update function de Empleados
+CREATE PROCEDURE ModificarEmpleado
+--ALTER PROCEDURE ModificarEmpleado
+  @nombreUsuario VARCHAR(10),
+  @contraseña VARCHAR(7)
+AS
+BEGIN
+	RETURN
+END
+GO
+
+-- sp creado únicamente para satisfacer al Entity Framework
+-- y mapearlo en el modelo como update function de Empleados
+CREATE PROCEDURE EliminarEmpleado
+--ALTER PROCEDURE EliminarEmpleado
+  @nombreUsuario VARCHAR(10),
+  @contraseña VARCHAR(7)
+AS
+BEGIN
+	RETURN 
+END
+GO
+
 -- ===============================================
 CREATE PROCEDURE AltaSeccion
 --ALTER PROCEDURE AltaSeccion

--- a/ModeloEF/Obligatorio.Context.cs
+++ b/ModeloEF/Obligatorio.Context.cs
@@ -135,5 +135,31 @@ namespace ModeloEF
     
             return ((IObjectContextAdapter)this).ObjectContext.ExecuteFunction("ModificarSeccion", codigoSeccionParameter, nuevoNombreParameter);
         }
+    
+        public virtual int EliminarEmpleado(string nombreUsuario, string contraseña)
+        {
+            var nombreUsuarioParameter = nombreUsuario != null ?
+                new ObjectParameter("nombreUsuario", nombreUsuario) :
+                new ObjectParameter("nombreUsuario", typeof(string));
+    
+            var contraseñaParameter = contraseña != null ?
+                new ObjectParameter("contraseña", contraseña) :
+                new ObjectParameter("contraseña", typeof(string));
+    
+            return ((IObjectContextAdapter)this).ObjectContext.ExecuteFunction("EliminarEmpleado", nombreUsuarioParameter, contraseñaParameter);
+        }
+    
+        public virtual int ModificarEmpleado(string nombreUsuario, string contraseña)
+        {
+            var nombreUsuarioParameter = nombreUsuario != null ?
+                new ObjectParameter("nombreUsuario", nombreUsuario) :
+                new ObjectParameter("nombreUsuario", typeof(string));
+    
+            var contraseñaParameter = contraseña != null ?
+                new ObjectParameter("contraseña", contraseña) :
+                new ObjectParameter("contraseña", typeof(string));
+    
+            return ((IObjectContextAdapter)this).ObjectContext.ExecuteFunction("ModificarEmpleado", nombreUsuarioParameter, contraseñaParameter);
+        }
     }
 }

--- a/ModeloEF/Obligatorio.edmx
+++ b/ModeloEF/Obligatorio.edmx
@@ -110,6 +110,10 @@
           <Parameter Name="codigoSeccion" Type="varchar" Mode="In" />
           <Parameter Name="nombre" Type="varchar" Mode="In" />
         </Function>
+        <Function Name="EliminarEmpleado" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="false" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
+          <Parameter Name="nombreUsuario" Type="varchar" Mode="In" />
+          <Parameter Name="contraseña" Type="varchar" Mode="In" />
+        </Function>
         <Function Name="EliminarPeriodista" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="false" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
           <Parameter Name="Cedula" Type="varchar" Mode="In" />
           <Parameter Name="ret" Type="int" Mode="InOut" />
@@ -119,6 +123,10 @@
           <Parameter Name="ret" Type="int" Mode="InOut" />
         </Function>
         <Function Name="Logueo" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="false" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
+          <Parameter Name="nombreUsuario" Type="varchar" Mode="In" />
+          <Parameter Name="contraseña" Type="varchar" Mode="In" />
+        </Function>
+        <Function Name="ModificarEmpleado" Aggregate="false" BuiltIn="false" NiladicFunction="false" IsComposable="false" ParameterTypeSemantics="AllowImplicitConversion" Schema="dbo">
           <Parameter Name="nombreUsuario" Type="varchar" Mode="In" />
           <Parameter Name="contraseña" Type="varchar" Mode="In" />
         </Function>
@@ -276,6 +284,14 @@
             <Parameter Name="codigoSeccion" Mode="In" Type="String" />
             <Parameter Name="nuevoNombre" Mode="In" Type="String" />
           </FunctionImport>
+          <FunctionImport Name="EliminarEmpleado">
+            <Parameter Name="nombreUsuario" Mode="In" Type="String" />
+            <Parameter Name="contraseña" Mode="In" Type="String" />
+          </FunctionImport>
+          <FunctionImport Name="ModificarEmpleado">
+            <Parameter Name="nombreUsuario" Mode="In" Type="String" />
+            <Parameter Name="contraseña" Mode="In" Type="String" />
+          </FunctionImport>
         </EntityContainer>
         <ComplexType Name="Logueo_Result">
           <Property Type="String" Name="NombreUsuario" Nullable="false" MaxLength="10" />
@@ -300,6 +316,10 @@
                   <ScalarProperty Name="Contraseña" ParameterName="contraseña" />
                   <ScalarProperty Name="NombreUsuario" ParameterName="nombreUsuario" />
                 </InsertFunction>
+                <UpdateFunction FunctionName="ObligatorioModel.Store.ModificarEmpleado" >
+                  <ScalarProperty Name="Contraseña" ParameterName="contraseña" Version="Current" />
+                  <ScalarProperty Name="NombreUsuario" ParameterName="nombreUsuario" Version="Current" />
+                </UpdateFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>
@@ -384,6 +404,8 @@
           </FunctionImportMapping>
           <FunctionImportMapping FunctionImportName="ModificarPeriodista" FunctionName="ObligatorioModel.Store.ModificarPeriodista" />
           <FunctionImportMapping FunctionImportName="ModificarSeccion" FunctionName="ObligatorioModel.Store.ModificarSeccion" />
+          <FunctionImportMapping FunctionImportName="EliminarEmpleado" FunctionName="ObligatorioModel.Store.EliminarEmpleado" />
+          <FunctionImportMapping FunctionImportName="ModificarEmpleado" FunctionName="ObligatorioModel.Store.ModificarEmpleado" />
         </EntityContainerMapping>
       </Mapping>
     </edmx:Mappings>

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -272,16 +272,21 @@ public class LogicaModeloEF
              * hacerse cambiando el valor de cada una de sus propiedades
              * 
              * **NO** puede reemplazarse el objeto Sección en la Noticia
-             * porque producirá una DuplicateKeyException en el Entity Framework:
-             * EF detectará que en el contexto hay un objeto diferente al que
-             * tiene en memoria con la misma clave primaria de un 
-             * objeto preexistente
+             * porque producirá una DuplicateKeyException en el Entity Framework
+             * al ejecutar la operación DbContext.SaveChanges:
+             * EF detectará que en el contexto ya hay un objeto Sección 
+             * con una cierta clave primaria y que se intenta agregar
+             * un objeto Sección diferente con la misma clave primaria 
+             * que el objeto Sección anterior
              * 
              * Rafael 20/11/2021
              */
             N.Secciones.CodigoSeccion = unaN.Secciones.CodigoSeccion;
             N.Secciones.Nombre = unaN.Secciones.Nombre;
             N.Secciones.Activo = unaN.Secciones.Activo;
+
+            N.Empleados.NombreUsuario = unaN.Empleados.NombreUsuario;
+            N.Empleados.Contraseña = unaN.Empleados.Contraseña;
 
             OEcontext.SaveChanges();
         }

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -260,13 +260,28 @@ public class LogicaModeloEF
 
             Noticias N = OEcontext.Noticias.Where(n => n.Codigo == unaN.Codigo).FirstOrDefault();
 
-            N.Codigo = unaN.Codigo;
+            // no se debe modificar el código de la noticia
             N.Cuerpo = unaN.Cuerpo;
             N.Titulo = unaN.Titulo;
             N.FechaPublicacion = unaN.FechaPublicacion;
             N.Importancia = unaN.Importancia;
             N.Periodistas = unaN.Periodistas;
-            N.Secciones = unaN.Secciones;
+
+            /**
+             * La actualización de los datos de la Sección de la Noticia debe 
+             * hacerse cambiando el valor de cada una de sus propiedades
+             * 
+             * **NO** puede reemplazarse el objeto Sección en la Noticia
+             * porque producirá una DuplicateKeyException en el Entity Framework:
+             * EF detectará que en el contexto hay un objeto diferente al que
+             * tiene en memoria con la misma clave primaria de un 
+             * objeto preexistente
+             * 
+             * Rafael 20/11/2021
+             */
+            N.Secciones.CodigoSeccion = unaN.Secciones.CodigoSeccion;
+            N.Secciones.Nombre = unaN.Secciones.Nombre;
+            N.Secciones.Activo = unaN.Secciones.Activo;
 
             OEcontext.SaveChanges();
         }


### PR DESCRIPTION
Con esta propuesta se corrigió un error, detectado por @floripas, en el que se intentaba actualizar una noticia en el sistema pero se lanzaba una excepción al momento de guardar los cambios.

El error era causado porque, al actualizar una `Noticia`, se reemplazaba el objeto `Sección` por un nuevo objeto `Sección`. 

```csharp
// Esta era la línea que causaba el error
N.Secciones = unaN.Secciones
```

Esto llevaba al Entity Framework a lanzar una excepción porque detectaba que en el contexto había 2 objetos `Sección` diferentes que tenían la misma clave primaria.

Se resolvió el error actualizando las propiedades del objeto `Sección` de la `Noticia` para así mantener la referencia a ese objeto.

Siguiendo la misma pauta, también se actualizan los datos del `Empleado` que carga/modifica la `Noticia`.

Queda todavía pendiente la resolución de los errores de la página `AltaModificacionNoticia.aspx`:

- El formulario no carga la fecha de la `Noticia`.
- El formulario no carga los `Periodistas` de una `Noticia`.
- El botón `Limpiar` no desmarca las casillas de los Periodistas.