### PR TITLE
Corrección de funcionalidad de búsqueda y alta de noticias

### DIFF
--- a/Base de Datos/Obligatorio.sql
+++ b/Base de Datos/Obligatorio.sql
@@ -379,6 +379,34 @@ Values ('codnot10', 'Titulo Noticia 10','Cuerpo Noticia 10', 3,DATEADD(DAY, -5, 
 ('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,GETDATE(), 'inter', 'Empleado40')
 GO
 
+INSERT INTO Escriben(Codigo, Cedula)
+VALUES('codnot1', '44259772'),
+('codnot2', '51237687'),
+('codnot3', '44259772'),
+('codnot3', '51237687'),
+('codnot3', '00000000'),
+('codnot4', '67839025'),
+('codnot5', '00000000'),
+('codnot6', '44259772'),
+('codnot7', '51237687'),
+('codnot8', '00000000'),
+('codnot8', '51237687'),
+('codnot9', '00000000'),
+('codnot10', '44259772'),
+('codnot11', '39867291'),
+('codnot11', '67839025'),
+('codnot12', '44259772'),
+('codnot13', '67839025'),
+('codnot13', '39867291'),
+('codnot13', '44259772'),
+('codnot14', '00000000'),
+('codnot15', '67839025'),
+('codnot16', '44259772'),
+('codnot16', '00000000'),
+('codnot16', '39867291'),
+('codnot16', '51237687')
+GO
+
 SELECT * FROM Empleados
 SELECT * FROM Secciones
 SELECT * FROM Periodistas

--- a/Sitio/AltaModificacionNoticias.aspx
+++ b/Sitio/AltaModificacionNoticias.aspx
@@ -40,7 +40,14 @@
                 <label>Fecha de publicación: </label>
             </td>
             <td>
-                <asp:TextBox ID="txtFecha" runat="server" TextMode="Date" Enabled="False"></asp:TextBox>
+                <asp:Calendar ID="cldFechaPublicacion" runat="server" BackColor="White" BorderColor="White" BorderWidth="1px" Enabled="True" Font-Names="Verdana" Font-Size="9pt" ForeColor="Black" Height="190px" NextPrevFormat="FullMonth" SelectedDate="1970-01-01" Width="350px" Visible="True">
+                    <DayHeaderStyle Font-Bold="True" Font-Size="8pt" />
+                    <NextPrevStyle Font-Bold="True" Font-Size="8pt" ForeColor="#333333" VerticalAlign="Bottom" />
+                    <OtherMonthDayStyle ForeColor="#999999" />
+                    <SelectedDayStyle BackColor="#333399" ForeColor="White" />
+                    <TitleStyle BackColor="White" BorderColor="Black" BorderWidth="4px" Font-Bold="True" Font-Size="12pt" ForeColor="#333399" />
+                    <TodayDayStyle BackColor="#CCCCCC" />
+                </asp:Calendar>
             </td>
         </tr>
         <tr>

--- a/Sitio/AltaModificacionNoticias.aspx
+++ b/Sitio/AltaModificacionNoticias.aspx
@@ -32,7 +32,8 @@
                 <label>Sección: </label>
             </td>
             <td>
-                <asp:DropDownList ID="ddlSecciones" runat="server" Enabled="False"></asp:DropDownList>
+                <asp:DropDownList ID="ddlSecciones" runat="server" Enabled="False">
+                </asp:DropDownList>
             </td>
         </tr>
         <tr>
@@ -56,6 +57,7 @@
             </td>
             <td>
                 <asp:DropDownList ID="ddlImportancia" runat="server" Enabled="False">
+                    <asp:ListItem Selected="True"></asp:ListItem>
                     <asp:ListItem>1</asp:ListItem>
                     <asp:ListItem>2</asp:ListItem>
                     <asp:ListItem>3</asp:ListItem>

--- a/Sitio/AltaModificacionNoticias.aspx.cs
+++ b/Sitio/AltaModificacionNoticias.aspx.cs
@@ -35,10 +35,17 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
 
     private void CargarDDLSecciones()
     {
-        ddlSecciones.DataSource = new ServicioEF().ListarSecciones().ToList();
+        List<Secciones> secciones = new ServicioEF().ListarSecciones().ToList();
+
+        Session["Secciones"] = secciones;
+
+        ddlSecciones.DataSource = secciones;
         ddlSecciones.DataValueField = "CodigoSeccion";
         ddlSecciones.DataTextField = "Nombre";
         ddlSecciones.DataBind();
+
+        // se selecciona el elemento vacío 
+        ddlSecciones.SelectedIndex = 0;
     }
     private void CargarChkPeriodistas()
     {


### PR DESCRIPTION
Esta propuesta corrige varios problemas que tenía la funcionalidad de alta y modificación de noticias. Los problemas eran variados: la mayoría en el formulario y la code-behind, pero había problemas en la clase `Servicio.LogicaModeloEF`.

Destaco los problemas en `Servicio.LogicaModeloEF` porque, aunque pocos, eran significativos:
- Al recuperar una `Noticia` del servicio, **el objeto estaba incompleto** porque no contaba con alguno de los objetos asociados (`Empleado`, `Sección` o `Periodistas`).
- Se cargaban objetos nuevos al `DbContext`, lo que producía un error porque Entity Framework detecta **objetos nuevos que tienen una clave primaria idéntica a la de objetos ya existentes en el contexto**. 

En cuanto a los problemas del formulario, lo más relevante es lo siguiente:
- No se cargaban en el formulario los datos de los `ListControl`: los controles de Importancia, Sección y Periodistas
- No se cargaban datos en el calendario; la razón es que era un textbox tipo calendario, no un control tipo calendario.

En el formulario `AltaModificacionNoticia.aspx` todavía queda pendiente la revisión y corrección sistemática de la modificación de noticias ya existentes y del funcionamiento del botón `Limpiar`.

El código está comentando explicando estos problemas y su resolución.