### PR TITLE
Corregir funcionalidades de Modificar Noticia y limpiar en AltaModificacionNoticia.aspx

### DIFF
--- a/Sitio/AltaModificacionNoticias.aspx.cs
+++ b/Sitio/AltaModificacionNoticias.aspx.cs
@@ -81,9 +81,9 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
     }
 
     /// <summary>
-    /// Limpia los controles del formulario y regresa al formulario 
-    /// en su estado inicial. 
-    /// 
+    /// Limpia los controles del formulario y regresa al formulario
+    /// en su estado inicial.
+    ///
     /// La operación limpia lblMensaje, por lo que debe invocarse antes
     /// de mostrar un mensaje de éxito
     /// </summary>
@@ -243,17 +243,41 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
     {
         try
         {
-            Session["Periodista"] = null;
-            DesactivoBotones();
-            LimpioControles();
-            btnBuscar.Enabled = true;
-            txtCodigo.Enabled = true;
-            txtCodigo.ReadOnly = false;
+            Session["Periodistas"] = null;
+            RegresarFormularioEstadoInicial();
         }
         catch (Exception ex)
         {
             lblMensaje.Text = ex.Message;
         }
+    }
+
+    /// <summary>
+    /// Pone al formulario en su estado inicial,
+    /// como si recién se cargara la página
+    ///
+    /// Debe invocarse antes de mostrar un mensaje de éxito, porque
+    /// la operación limpia el contenido de lblMensaje
+    /// </summary>
+    private void RegresarFormularioEstadoInicial()
+    {
+        DesactivoBotones();
+        LimpioControles();
+
+        chkPeriodistas.Enabled = false;
+        chkPeriodistas.Visible = false;
+
+        txtCodigo.Enabled = true;
+        txtCodigo.ReadOnly = false;
+
+        btnBuscar.Enabled = true;
+        btnBuscar.Visible = true;
+
+        btnCrear.Enabled = false;
+        btnCrear.Visible = false;
+
+        btnModificar.Enabled = false;
+        btnModificar.Visible = false;
     }
 
     protected void btnModificar_Click(object sender, EventArgs e)
@@ -275,10 +299,9 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
 
             LimpioControles();
 
-            lblMensaje.Text = "Modificación con Exito";
+            RegresarFormularioEstadoInicial();
 
-            btnCrear.Enabled = false;
-            btnModificar.Enabled = false;
+            lblMensaje.Text = "Modificación con Exito";
         }
         catch (System.Web.Services.Protocols.SoapException ex)
         {
@@ -362,10 +385,9 @@ public partial class AltaModificacionNacionales : System.Web.UI.Page
 
             LimpioControles();
 
-            lblMensaje.Text = "Alta con Exito";
+            RegresarFormularioEstadoInicial();
 
-            btnCrear.Enabled = false;
-            btnModificar.Enabled = false;
+            lblMensaje.Text = "Alta con Exito";
         }
         catch (System.Web.Services.Protocols.SoapException ex)
         {


### PR DESCRIPTION
La corrección más importante de la funcionalidades de Modificar una noticia tuvo lugar en la operación `LogicaModeloEF.ModificarNoticia`.

## Cambios en `LogicaModeloEF.ModificarNoticia`
El problema en esta operación era que se estaban cargando nuevos objetos en el `DbContext`, por lo que Entity Framework lanzaba una excepción. La corrección consistió en que los nuevos objetos asociados a la `Noticia` (`Empleado`, `Sección`, `Periodistas`) se recuperan desde el `DbContext` y son estos objetos, que contienen los datos que deseamos, los que se cargan a la `Noticia` que se está modificando.

También escribí operaciones auxiliares de esta clase para que el código en las operaciones más importantes, como AltaNoticia y ModificarNoticia, fuera mucho más fácil de entender.

## Cambios en el formulario `AltaModificacionNoticia.aspx`
Los cambios realizados en el formulario fueron de diferente alcance, pero los objetivos generales eran

### Hacer el código de la code-behind lo más claro y correcto posible
Con la creación de operaciones auxiliares que permitan evitar la repetición de código y den un nombre (y un concepto) a las acciones que se están realizando

### Hacer que la experiencia de usuario sea más "correcta"
- Al ocultar botones y controles inhabilitados que no muestren visualmente que están inhabilitados (calendario y checkBoxList).
- Corrección de mensajes de error que se mostrarán al usuario.
- Añadir items vacíos a los menús desplegables para que el usuario tenga que elegir deliberadamente un item.
- Limpiar efectivamente todos los campos del formulario
- Lograr que el formulario logre obtener los estados deseados con cada acción del usuario, incluso cuando hay un error.

Cada uno de los cambios específicos puede consultarse en el mensaje de cada uno de los commits de esta propuesta y se pueden consultar más abajo.