### PR TITLE
Implementar funcionalidad para filtrar noticias en Default.aspx

### DIFF
--- a/Base de Datos/Obligatorio.sql
+++ b/Base de Datos/Obligatorio.sql
@@ -371,12 +371,12 @@ GO
 -- para actualizar automáticamente las fechas de las noticias a mostrar
 INSERT INTO Noticias(Codigo, Titulo, Cuerpo, Importancia, FechaPublicacion, CodigoSeccion, NombreUsuario)
 Values ('codnot10', 'Titulo Noticia 10','Cuerpo Noticia 10', 3,DATEADD(DAY, -5, GETDATE()), 'inter', 'Empleado40'),
-('codnot11', 'Titulo Noticia 11','Cuerpo Noticia 11', 4,DATEADD(DAY, -5, GETDATE()), 'inter', 'Empleado20'),
+('codnot11', 'Titulo Noticia 11','Cuerpo Noticia 11', 4,DATEADD(DAY, -5, GETDATE()), 'depor', 'Empleado20'),
 ('codnot12', 'Titulo Noticia 12','Cuerpo Noticia 12', 3,DATEADD(DAY, -3, GETDATE()), 'inter', 'Empleado10'),
-('codnot13', 'Titulo Noticia 13','Cuerpo Noticia 13', 1,DATEADD(DAY, -1, GETDATE()), 'inter', 'Empleado30'),
-('codnot14', 'Titulo Noticia 14','Cuerpo Noticia 14', 3,DATEADD(DAY, -1, GETDATE()), 'inter', 'Empleado20'),
-('codnot15', 'Titulo Noticia 15','Cuerpo Noticia 15', 3,GETDATE(), 'inter', 'Empleado10'),
-('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,GETDATE(), 'inter', 'Empleado40')
+('codnot13', 'Titulo Noticia 13','Cuerpo Noticia 13', 1,DATEADD(DAY, -1, GETDATE()), 'cultu', 'Empleado30'),
+('codnot14', 'Titulo Noticia 14','Cuerpo Noticia 14', 3,DATEADD(DAY, -1, GETDATE()), 'econo', 'Empleado20'),
+('codnot15', 'Titulo Noticia 15','Cuerpo Noticia 15', 3,GETDATE(), 'econo', 'Empleado10'),
+('codnot16', 'Titulo Noticia 16','Cuerpo Noticia 16', 3,GETDATE(), 'cultu', 'Empleado40')
 GO
 
 INSERT INTO Escriben(Codigo, Cedula)

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -49,13 +49,13 @@
             <asp:DropDownList ID="ddlFiltroSeccion" runat="server" AutoPostBack="True" OnSelectedIndexChanged="ddlFiltroSeccion_SelectedIndexChanged">
                 <asp:ListItem Selected="True">Sin filtro</asp:ListItem>
             </asp:DropDownList>
-                 <asp:Button ID="btnLimpiar" runat="server" Text="Limpiar filtros" />
+                 <asp:Button ID="btnLimpiar" runat="server" Text="Limpiar filtros" OnClick="btnLimpiar_Click" />
             </div>
             <div>
                 <p class="instrucciones-filtro">
                 Filtra las noticias por fecha usando este menú desplegable: 
             </p>
-            <asp:DropDownList ID="ddlFiltroFecha" runat="server" AutoPostBack="True">
+            <asp:DropDownList ID="ddlFiltroFecha" runat="server" AutoPostBack="True" OnSelectedIndexChanged="ddlFiltroFecha_SelectedIndexChanged">
                 <asp:ListItem Selected="True">Sin filtro</asp:ListItem>
                 </asp:DropDownList>
             </div>

--- a/Sitio/Default.aspx
+++ b/Sitio/Default.aspx
@@ -5,15 +5,60 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head runat="server">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <title></title>
+    <title>Listado de noticias de los últimos 5 días</title>
+    <style>
+        .form {
+            margin: 0 auto;
+            display: flex;
+            justify-content: center;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .form p:first-of-type{
+            text-align: right;
+        }
+
+        #grdNoticias {
+            margin: 1em 0;
+        }
+
+        .filtros {
+            display: flex;
+            flex-direction: column;
+            margin: 1em 0;
+        }
+
+        .instrucciones-filtro {
+            display: inline-block;
+        }
+
+        .filtros select {
+            margin: 0 2em;
+        }
+    </style>
 </head>
 <body>
-    <form id="form1" runat="server">
-        <div>
-            <p style="display: inline;">Filtra las noticias por secciones usando este menú desplegable: </p>
+    <form id="form1" runat="server" class="form">
+        <div class="filtros">
+            <p>
+                <asp:HyperLink ID="HyperLink1" runat="server" NavigateUrl="~/Logueo.aspx">Loguéate</asp:HyperLink>
+            </p>
+            <div>
+                <p class="instrucciones-filtro">Filtra las noticias por secciones usando este menú desplegable: </p>
             <asp:DropDownList ID="ddlFiltroSeccion" runat="server" AutoPostBack="True" OnSelectedIndexChanged="ddlFiltroSeccion_SelectedIndexChanged">
                 <asp:ListItem Selected="True">Sin filtro</asp:ListItem>
             </asp:DropDownList>
+                 <asp:Button ID="btnLimpiar" runat="server" Text="Limpiar filtros" />
+            </div>
+            <div>
+                <p class="instrucciones-filtro">
+                Filtra las noticias por fecha usando este menú desplegable: 
+            </p>
+            <asp:DropDownList ID="ddlFiltroFecha" runat="server" AutoPostBack="True">
+                <asp:ListItem Selected="True">Sin filtro</asp:ListItem>
+                </asp:DropDownList>
+            </div>
         </div>
         <div>
             <asp:GridView ID="grdNoticias" runat="server" AutoGenerateColumns="False" OnSelectedIndexChanged="grdNoticias_SelectedIndexChanged">

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -21,6 +21,8 @@ public partial class _Default : System.Web.UI.Page
                 CargarDdlFiltroSeccion(servicio);
 
                 CargarNoticiasEnGrilla(servicio);
+
+                CargarFechasEnFiltro();
             }
         }
         catch (SoapException ex)
@@ -30,6 +32,19 @@ public partial class _Default : System.Web.UI.Page
         catch (Exception ex)
         {
             lblMensaje.Text = ex.Message;
+        }
+    }
+
+    private void CargarFechasEnFiltro()
+    {
+        ListItem item;
+        DateTime fecha;
+
+        for (int i = 0; i < 5; i++)
+        {
+            fecha = DateTime.Today.AddDays(-i); 
+            item = new ListItem(fecha.ToShortDateString(), fecha.ToShortDateString());
+            ddlFiltroFecha.Items.Add(item);
         }
     }
 
@@ -89,8 +104,7 @@ public partial class _Default : System.Web.UI.Page
 
             if (codigoSeccionSeleccionada.ToLower() == "sin filtro")
             {
-                grdNoticias.DataSource = noticias;
-                lblMensaje.Text = "";
+                LimpiarFiltros();
             }
             else
             {
@@ -111,5 +125,25 @@ public partial class _Default : System.Web.UI.Page
         {
             lblMensaje.Text = ex.Message;
         }
+    }
+
+    protected void ddlFiltroFecha_SelectedIndexChanged(object sender, EventArgs e)
+    {
+
+    }
+
+    protected void btnLimpiar_Click(object sender, EventArgs e)
+    {
+        LimpiarFiltros();
+    }
+
+    private void LimpiarFiltros()
+    {
+        List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+
+        lblMensaje.Text = "";
+        
+        grdNoticias.DataSource = noticias;
+        grdNoticias.DataBind();
     }
 }

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -16,6 +16,10 @@ public partial class _Default : System.Web.UI.Page
         {
             if (!IsPostBack)
             {
+                Session["secciones"] = null;
+                Session["noticias"] = null;
+                Session["noticiaSeleccionada"] = null;
+
                 ServicioEF servicio = new ServicioEF();
 
                 CargarDdlFiltroSeccion(servicio);
@@ -100,26 +104,7 @@ public partial class _Default : System.Web.UI.Page
         {
             List<Noticias> noticias = (List<Noticias>)Session["noticias"];
 
-            string codigoSeccionSeleccionada = ddlFiltroSeccion.SelectedValue;
-
-            if (codigoSeccionSeleccionada.ToLower() == "sin filtro")
-            {
-                LimpiarFiltros();
-            }
-            else
-            {
-                List<Noticias> noticiasFiltradas = noticias
-                .Where(noticia => noticia.Secciones.CodigoSeccion == codigoSeccionSeleccionada)
-                .ToList<Noticias>();
-
-                grdNoticias.DataSource = noticiasFiltradas;
-
-                lblMensaje.Text = noticiasFiltradas.Count > 0
-                    ? "" 
-                    : "Ninguna noticia reciente se publicó en la sección " + ddlFiltroSeccion.SelectedItem.Text;
-            }
-            
-            grdNoticias.DataBind();
+            FiltrarNoticias(noticias, ddlFiltroFecha.SelectedValue, ddlFiltroSeccion.SelectedValue);
         }
         catch (Exception ex)
         {
@@ -127,9 +112,88 @@ public partial class _Default : System.Web.UI.Page
         }
     }
 
+    private void FiltrarNoticiasPorSeccionYFecha(List<Noticias> noticias, string codigoSeccion, string fecha)
+    {
+        List<Noticias> noticiasFiltradas = noticias
+            .Where(noticia => noticia.Secciones.CodigoSeccion == codigoSeccion)
+            .Where(noticia => noticia.FechaPublicacion.ToShortDateString() == fecha)
+            .ToList<Noticias>();
+
+        grdNoticias.DataSource = noticiasFiltradas;
+        grdNoticias.DataBind();
+
+        lblMensaje.Text = noticiasFiltradas.Count > 0
+            ? ""
+            : "Ninguna noticia reciente se publicó en la sección " + codigoSeccion + " el día " + fecha;
+    }
+
+    private void FiltrarNoticiasPorFecha(List<Noticias> noticias, string fecha)
+    {
+        List<Noticias> noticiasFiltradas = noticias
+            .Where(noticia => noticia.FechaPublicacion.ToShortDateString() == fecha)
+            .ToList<Noticias>();
+
+        grdNoticias.DataSource = noticiasFiltradas;
+        grdNoticias.DataBind();
+
+        lblMensaje.Text = noticiasFiltradas.Count > 0
+                    ? ""
+                    : "Ninguna noticia reciente se publicó en la fecha " + fecha;
+    }
+
+    private void FiltrarNoticiasPorSeccion(List<Noticias> noticias, string codigoSeccion)
+    {
+        List<Noticias> noticiasFiltradas = noticias
+            .Where(noticia => noticia.Secciones.CodigoSeccion == codigoSeccion)
+            .ToList<Noticias>();
+
+        grdNoticias.DataSource = noticiasFiltradas;
+        grdNoticias.DataBind();
+
+        lblMensaje.Text = noticiasFiltradas.Count > 0
+            ? ""
+            : "Ninguna noticia reciente se publicó en la sección " + codigoSeccion;
+    }
+
     protected void ddlFiltroFecha_SelectedIndexChanged(object sender, EventArgs e)
     {
+        try
+        {
+            List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+            
+            FiltrarNoticias(noticias, ddlFiltroFecha.SelectedValue, ddlFiltroSeccion.SelectedValue);
+        }
+        catch (Exception ex)
+        {
+            lblMensaje.Text = ex.Message;
+        }
+    }
 
+    /// <summary>
+    /// Filtra la lista de noticias usando la fecha 
+    /// y el código de sección recibidos
+    /// </summary>
+    /// <param name="noticias">Listado de noticias a filtrar</param>
+    /// <param name="fechaSeleccionada">Un string que representa una fecha</param>
+    /// <param name="codigoSeccion">El código de la sección</param>
+    private void FiltrarNoticias(List<Noticias> noticias, string fechaSeleccionada, string codigoSeccion)
+    {
+        if (codigoSeccion.ToLower() == "sin filtro" && fechaSeleccionada.ToLower() == "sin filtro")
+        {
+            LimpiarFiltros();
+        }
+        else if (codigoSeccion.ToLower() != "sin filtro" && fechaSeleccionada.ToLower() == "sin filtro")
+        {
+            FiltrarNoticiasPorSeccion(noticias, codigoSeccion);
+        }
+        else if (codigoSeccion.ToLower() == "sin filtro" && fechaSeleccionada.ToLower() != "sin filtro")
+        {
+            FiltrarNoticiasPorFecha(noticias, fechaSeleccionada);
+        }
+        else
+        {
+            FiltrarNoticiasPorSeccionYFecha(noticias, codigoSeccion, fechaSeleccionada);
+        }
     }
 
     protected void btnLimpiar_Click(object sender, EventArgs e)
@@ -140,6 +204,9 @@ public partial class _Default : System.Web.UI.Page
     private void LimpiarFiltros()
     {
         List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+
+        ddlFiltroFecha.SelectedIndex = 0;
+        ddlFiltroSeccion.SelectedIndex = 0;
 
         lblMensaje.Text = "";
         

--- a/Sitio/MostrarNoticia.ascx
+++ b/Sitio/MostrarNoticia.ascx
@@ -91,7 +91,7 @@
         <td class="auto-style32" style="border-style: none;"></td>
     </tr>
     <tr>
-        <td class="auto-style28">Tipo: <asp:Label ID="lblTipo" runat="server"></asp:Label>
+        <td class="auto-style28">
         </td>
         <td class="auto-style29"></td>
         <td class="auto-style27">Redactado por:</td>


### PR DESCRIPTION
En esta propuesta se implementó el filtrado de noticias en `Default.aspx` por sección y/o fecha seleccionadas.

Fue necesario intervenir en el marcado de la página `Default.aspx` para añadir el menú desplegable para filtrar por fecha y el botón de limpiar filtros. También hubo varios ajustes de CSS para dar a la página una apariencia prolija. 

## Filtrado de las noticias
Los filtros se implementaron a través de 2 menús desplegables, uno para filtrar por fecha y otro para la sección. 

Lo más relevante es el código que controla el filtrado de las noticias que se despliegan en la grilla. Ya que hay 2 filtros que pueden influir al mismo tiempo en lo que se carga en la grilla, cada filtro tiene que tomar en cuenta el estado del otro. 

Esta circunstancias reduce a 4 los posibles estados de la grilla de noticias:

- Sin filtro alguno
- Noticias filtradas por sección
- Noticias filtradas por fecha
- Noticias filtradas por sección y por fecha

En vista de que ambos manejadores de selección deben contemplar estos 4 casos, se extrajo esa lógica a la operación auxiliar `Default.FiltrarNoticias`. Esta operación también tiene 4 operaciones auxiliares que llevan a la página al estado deseado en cada caso.