### PR TITLE
Corregir error en baja de Secciones - ABMSecciones.aspx

### DIFF
--- a/Sitio/ABMSecciones.aspx.cs
+++ b/Sitio/ABMSecciones.aspx.cs
@@ -59,7 +59,7 @@ public partial class ABMSecciones : System.Web.UI.Page
             lblMensaje.Text = ex.Message;
         }
     }
-
+    
     protected void btnLimpiar_Click(object sender, EventArgs e)
     {
         txtCodigoSeccion.Text = "";
@@ -121,12 +121,12 @@ public partial class ABMSecciones : System.Web.UI.Page
 
             PonerFormularioEnEstadoInicial();
 
+            txtCodigoSeccion.Text = "";
+            txtNombreSeccion.Text = "";
+
+            PonerFormularioEnEstadoInicial();
+
             lblMensaje.Text = "Baja con Exito";
-
-            //txtCodigoSeccion.Text = "";
-            //txtNombreSeccion.Text = "";
-
-            //PonerFormularioEnEstadoInicial();
         }
         catch (System.Web.Services.Protocols.SoapException ex)
         {
@@ -148,14 +148,9 @@ public partial class ABMSecciones : System.Web.UI.Page
 
             new ServicioEF().ModificarSeccion(_unaS);
 
+            PonerFormularioEnEstadoInicial();
+
             lblMensaje.Text = "Modificación con Exito";
-
-            txtNombreSeccion.Text = "";
-            txtCodigoSeccion.Text = "";
-
-            btnCrear.Enabled = false;
-            btnEliminar.Enabled = false;
-            btnModificar.Enabled = false;
         }
         catch (System.Web.Services.Protocols.SoapException ex)
         {
@@ -167,6 +162,14 @@ public partial class ABMSecciones : System.Web.UI.Page
         }
     }
 
+    /// <summary>
+    /// Devuelve el formulario a su estado inicial, en el que 
+    /// el usuario puede hacer una búsqueda de sección.
+    /// 
+    /// Debe invocarse **ANTES** de mostrar un mensaje de éxito,
+    /// pues la operación vacía el contenido de la label
+    /// de mensajes
+    /// </summary>
     private void PonerFormularioEnEstadoInicial()
     {
         lblMensaje.ForeColor = System.Drawing.Color.Black;


### PR DESCRIPTION
Quedó resuelto el error que reportó @floripas al eliminar un objeto Sección del contexto y luego intentar darle de alta otra vez. 

El error obtenido contenía el siguiente mensaje:

`Saving or accepting changes failed because more than one entity of type ModeloEF.Secciones have the same primary key value`

## ¿Por qué se presentaba el error?
Este error solo se produce cuando el contexto encuentra que tiene dos objetos con la misma clave primaria, lo que indicaba que de alguna manera el objeto `Sección` eliminado todavía se encontraba en el contexto.

De acuerdo con la definición del estado `Deleted` de las entidades del EF que ofrece Microsoft:

> **Deleted**: The object has been deleted from the object context. After the changes are saved, the object state changes to [Detached](https://docs.microsoft.com/en-us/dotnet/api/system.data.entitystate?view=netframework-4.8#System_Data_EntityState_Detached).

**Un objeto adquiere el estado `Detached` después de haber sido eliminado**, es decir, el contexto no rastreará más cambios en él.

Y la definición de `Detached` es la siguiente:

> **Detached**: The object exists but is not being tracked. An entity is in this state immediately after it has been created and before it is added to the object context. An entity is also in this state after it has been removed from the context by calling the Detach(Object) method or if it is loaded by using a NoTrackingMergeOption. There is no ObjectStateEntry instance associated with objects in the Detached state.

Debo destacar el inicio de la definición:  _**El objeto existe pero no está siendo rastreado**_. 

Esto significa que, al eliminar un objeto del contexto, la operación elimina el registro correspondiente de la base de datos, pero la entidad correspondiente podría quedar todavía en el contexto. 

Esta sería la razón por la cual el objeto `DbContext` lanza la excepción ya mencionada.

## ¿Cómo se resolvió el problema?
[Según esta respuesta de StackOverflow](https://stackoverflow.com/questions/27423059/how-do-i-clear-tracked-entities-in-entity-framework/49561627#49561627), la manera más simple de dereferenciar entidades en el `DbContext` es eliminar el objeto `DbContext` entero e instanciarlo de nuevo.

Con este objetivo, se agregó un setter a la propiedad `LogicaModeloEF.OEcontext`. Este setter se usa en un bloque `finally` para anular el `DbContext` utilizado.

El getter de la propiedad `LogicaModeloEF.OEcontext` reinstanciará el objeto `DbContext` cuando este se invoque.





