### PR TITLE
Corrección de error de selección de noticias a consultar - Default.aspx

### DIFF
--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -19,6 +19,7 @@ public partial class _Default : System.Web.UI.Page
                 Session["secciones"] = null;
                 Session["noticias"] = null;
                 Session["noticiaSeleccionada"] = null;
+                Session["noticiasFiltradas"] = null;
 
                 ServicioEF servicio = new ServicioEF();
 
@@ -46,7 +47,7 @@ public partial class _Default : System.Web.UI.Page
 
         for (int i = 0; i < 5; i++)
         {
-            fecha = DateTime.Today.AddDays(-i); 
+            fecha = DateTime.Today.AddDays(-i);
             item = new ListItem(fecha.ToShortDateString(), fecha.ToShortDateString());
             ddlFiltroFecha.Items.Add(item);
         }
@@ -72,6 +73,7 @@ public partial class _Default : System.Web.UI.Page
         List<Noticias> noticias = servicio.MostrarNoticiasUltimosCincoDias().ToList<Noticias>();
 
         Session["noticias"] = noticias;
+        Session["noticiasFiltradas"] = noticias;
 
         grdNoticias.DataSource = noticias;
         grdNoticias.DataBind();
@@ -81,7 +83,11 @@ public partial class _Default : System.Web.UI.Page
     {
         try
         {
-            List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+            // si hay noticias filtradas, se carga noticias con ellas;
+            // de lo contrario, se carga con las noticias sin filtrar
+            List<Noticias> noticias = (List<Noticias>)Session["noticiasFiltradas"] != null && ((List<Noticias>)Session["noticiasFiltradas"]).Count > 0 
+                ? (List<Noticias>)Session["noticiasFiltradas"] 
+                : (List<Noticias>)Session["noticias"];
 
             Noticias noticiaSeleccionada = noticias[grdNoticias.SelectedIndex];
 
@@ -136,6 +142,8 @@ public partial class _Default : System.Web.UI.Page
         grdNoticias.DataSource = noticiasFiltradas;
         grdNoticias.DataBind();
 
+        Session["noticiasFiltradas"] = noticiasFiltradas;
+
         lblMensaje.Text = noticiasFiltradas.Count > 0
             ? ""
             : "Ninguna noticia reciente se publicó en la sección " + codigoSeccion + " el día " + fecha;
@@ -149,6 +157,8 @@ public partial class _Default : System.Web.UI.Page
 
         grdNoticias.DataSource = noticiasFiltradas;
         grdNoticias.DataBind();
+
+        Session["noticiasFiltradas"] = noticiasFiltradas;
 
         lblMensaje.Text = noticiasFiltradas.Count > 0
                     ? ""
@@ -164,6 +174,8 @@ public partial class _Default : System.Web.UI.Page
         grdNoticias.DataSource = noticiasFiltradas;
         grdNoticias.DataBind();
 
+        Session["noticiasFiltradas"] = noticiasFiltradas;
+
         lblMensaje.Text = noticiasFiltradas.Count > 0
             ? ""
             : "Ninguna noticia reciente se publicó en la sección " + codigoSeccion;
@@ -174,7 +186,7 @@ public partial class _Default : System.Web.UI.Page
         try
         {
             List<Noticias> noticias = (List<Noticias>)Session["noticias"];
-            
+
             FiltrarNoticias(noticias, ddlFiltroFecha.SelectedValue, ddlFiltroSeccion.SelectedValue);
         }
         catch (Exception ex)
@@ -218,12 +230,13 @@ public partial class _Default : System.Web.UI.Page
     private void LimpiarFiltros()
     {
         List<Noticias> noticias = (List<Noticias>)Session["noticias"];
+        Session["noticiasFiltradas"] = noticias;
 
         ddlFiltroFecha.SelectedIndex = 0;
         ddlFiltroSeccion.SelectedIndex = 0;
 
         lblMensaje.Text = "";
-        
+
         grdNoticias.DataSource = noticias;
         grdNoticias.DataBind();
     }

--- a/Sitio/Default.aspx.cs
+++ b/Sitio/Default.aspx.cs
@@ -87,7 +87,21 @@ public partial class _Default : System.Web.UI.Page
 
             Session["noticiaSeleccionada"] = noticiaSeleccionada;
             Response.Redirect("~/ConsultaNoticia.aspx");
+
+            return;
         }
+        /**
+         * Response.Redirect lanza una excepción ThreadAbortException
+         * para detener la ejecución del hilo actual y proceder
+         * a realizar la redirección
+         *
+         * @see https://stackoverflow.com/a/12957854/6951887
+         * 
+         * Este catch sirve para capturar e ignorar esta excepción
+         * 
+         * Rafael 28/11/2021
+         */
+        catch (System.Threading.ThreadAbortException ex) { }
         catch (SoapException ex)
         {
             lblMensaje.Text = ex.Detail.InnerText;


### PR DESCRIPTION
Después de filtrar la grilla, se mostraban los datos de una noticia diferente a la elegida. 

El problema consistía en que se elegía la noticia consultando el **índice seleccionado de la lista de noticias sin filtrar, no de la lista de noticias filtradas**.

Se añade la lista de noticias filtradas a la `Session` para guardar allí y consultar las noticias filtradas. Entonces son estas las que se usan para mostrar en la grilla de noticias y para consultar.

## Error al redirigir usuario a consulta de noticia
También detecté que se lanzaba una excepción al redirigir al usuario para consultar la noticia seleccionada. 

Según [esta respuesta en Stackoverflow](https://stackoverflow.com/a/12957854/6951887), la operación `Response.Redirect` lanza una excepción `ThreadAbortException` para detener la ejecución del código restante en el hilo actual y, después de ello, hace la redirección.

Esta excepción era capturada por el bloque `catch(Exception ex)` y cargaba el mensaje de error en `lblMensaje`, aunque debido a la redirección era difícil para el usuario darse cuenta de ello.

El nuevo bloque `catch` captura esa excepción para luego ignorarla. El cambio se propone por prolijidad