### PR TITLE
Corrección de baja lógica de secciones

### DIFF
--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -272,7 +272,7 @@ public class LogicaModeloEF
     {
         try
         {
-            Secciones S = OEcontext.Secciones.Where(s => s.CodigoSeccion == unaS.CodigoSeccion).FirstOrDefault();
+            Secciones S = OEcontext.Secciones.Where(s => s.CodigoSeccion == unaS.CodigoSeccion && s.Activo).FirstOrDefault();
 
             S.Nombre = unaS.Nombre;
 
@@ -352,7 +352,7 @@ public class LogicaModeloEF
             else
             {
                 OEcontext.SaveChanges();
-                //OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
+                OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -233,21 +233,32 @@ public class LogicaModeloEF
         {
             S = OEcontext.Secciones.Where(s => s.CodigoSeccion == unaS.CodigoSeccion).FirstOrDefault();
 
-            if (S != null)
+            // caso sección existe y está activa
+            if (S != null && S.Activo)
             {
                 throw new Exception("Ya existe una seccion con ese codigo.");
             }
-
-            S = new Secciones()
+            // caso sección existe pero está inactiva
+            else if (S != null && !S.Activo)
             {
-                Nombre = unaS.Nombre,
-                CodigoSeccion = unaS.CodigoSeccion
-            };
+                // no se actualiza el código, porque es inmodificable
+                S.Nombre = unaS.Nombre;
+                S.Activo = true;
+            }
+            // caso sección no existe físicamente en la base de datos
+            else
+            {
+                S = new Secciones()
+                {
+                    Nombre = unaS.Nombre,
+                    CodigoSeccion = unaS.CodigoSeccion
+                };
 
-            new Validaciones().Validar(S);
+                new Validaciones().Validar(S);
 
-            OEcontext.Secciones.Add(S);
-            OEcontext.SaveChanges();
+                OEcontext.Secciones.Add(S);
+                OEcontext.SaveChanges();
+            }
         }
         catch (Exception ex)
         {
@@ -341,7 +352,7 @@ public class LogicaModeloEF
             else
             {
                 OEcontext.SaveChanges();
-                OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
+                //OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -223,7 +223,7 @@ public class LogicaModeloEF
     #region Operaciones Secciones
     public static Secciones BuscarSeccion(string cod)
     {
-        return (OEcontext.Secciones.Where(s => s.CodigoSeccion == cod).FirstOrDefault());
+        return (OEcontext.Secciones.Where(s => s.CodigoSeccion == cod && s.Activo).FirstOrDefault());
     }
 
     public static void AltaSeccion(Secciones unaS)

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -248,7 +248,6 @@ public class LogicaModeloEF
 
             OEcontext.Secciones.Add(S);
             OEcontext.SaveChanges();
-            OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
         }
         catch (Exception ex)
         {

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -369,7 +369,7 @@ public class LogicaModeloEF
 
     public static List<Secciones> ListarSecciones()
     {
-        return (OEcontext.Secciones.ToList());
+        return (OEcontext.Secciones.Where(seccion => seccion.Activo).ToList());
     }
     #endregion
 


### PR DESCRIPTION
Esta propuesta tiene como objetivo resolver errores relacionados con la baja lógica de las secciones.

En eliminar, la baja lógica permite desactivar las secciones que el usuario desea eliminar. Sin embargo, eso también tiene consecuencias en el buscar, listar, alta y modificación de secciones. 

## Cambios en Buscar y Listar secciones
En los procedimientos `LogicaModeloEF.BuscarSeccion` y `LogicaModeloEF.ListarSecciones` se filtra el listado de secciones para devolver solo las secciones activas. 

## Cambios en Alta y Modificación de secciones
En la operación `LogicaModeloEF.AltaSeccion` se comienza con una búsqueda de un objeto sección en el `DbContext` y, si se encuentra una sección con el código ingresado, se lanza una excepción. Eso basta cuando no se aplica una baja lógica. 

Sin embargo, cuando se aplica una baja lógica, es necesario contemplar la posibilidad de que se encuentre una sección que esté inactiva. El código agregado contempla este caso. 

`LogicaModeloEF.ModificarSeccion` también comienza con una búsqueda de un objeto sección en el `DbContext`. La propuesta contempla que esa búsqueda se realice solo entre las secciones activas. 