### PR TITLE
eliminar en LogicaModeloEF.AltaSeccion lanzamiento de excepción en caso de éxito de alta

### DIFF
--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -259,7 +259,6 @@ public class LogicaModeloEF
             if ((int)_retorno.Value == 1)
             {
                 OEcontext.SaveChanges();
-                throw new Exception("La sección se eliminó correctamente.");
             }
             else
             {


### PR DESCRIPTION
La operación lanza una excepción en caso de éxito. Eso no parece correcto, pues la excepción se utiliza cuando se produce un error en algún proceso