### PR TITLE
Corrección de ABMSecciones.aspx.cs

### DIFF
--- a/Sitio/ABMSecciones.aspx.cs
+++ b/Sitio/ABMSecciones.aspx.cs
@@ -118,11 +118,6 @@ public partial class ABMSecciones : System.Web.UI.Page
 
             PonerFormularioEnEstadoInicial();
 
-            txtCodigoSeccion.Text = "";
-            txtNombreSeccion.Text = "";
-
-            PonerFormularioEnEstadoInicial();
-
             lblMensaje.Text = "Baja con Exito";
         }
         catch (System.Web.Services.Protocols.SoapException ex)

--- a/Sitio/ABMSecciones.aspx.cs
+++ b/Sitio/ABMSecciones.aspx.cs
@@ -62,9 +62,6 @@ public partial class ABMSecciones : System.Web.UI.Page
     
     protected void btnLimpiar_Click(object sender, EventArgs e)
     {
-        txtCodigoSeccion.Text = "";
-        txtNombreSeccion.Text = "";
-
         PonerFormularioEnEstadoInicial();
     }
 


### PR DESCRIPTION
En `ABMSecciones.btnLimpiar_Click` y `ABMSecciones.btnEliminar_Click` se limpiaban los campos del formulario innecesariamente. 

Ya de esto se encarga la operación auxiliar `ABMSecciones.PonerFormularioEnEstadoInicial`.