### PR TITLE
Exploración de eliminar secciones y periodistas

### DIFF
--- a/ModeloEF/Obligatorio.edmx
+++ b/ModeloEF/Obligatorio.edmx
@@ -352,6 +352,9 @@
                   <ScalarProperty Name="Nombre" ParameterName="Nombre" Version="Current" />
                   <ScalarProperty Name="Cedula" ParameterName="Cedula" Version="Current" />
                 </UpdateFunction>
+                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarPeriodista" RowsAffectedParameter="ret">
+                  <ScalarProperty Name="Cedula" ParameterName="Cedula" />
+                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>
@@ -372,6 +375,9 @@
                   <ScalarProperty Name="Nombre" ParameterName="nuevoNombre" Version="Current" />
                   <ScalarProperty Name="CodigoSeccion" ParameterName="codigoSeccion" Version="Current" />
                 </UpdateFunction>
+                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarSeccion" RowsAffectedParameter="ret">
+                  <ScalarProperty Name="CodigoSeccion" ParameterName="CodigoSeccion" />
+                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -21,11 +21,6 @@ public class LogicaModeloEF
             }
             return _OEcontext;
         }
-        //para poder anular el contexto y reinstanciarlo otra vez
-        set
-        {
-            _OEcontext = value;
-        }
     }
 
 
@@ -138,6 +133,13 @@ public class LogicaModeloEF
     {
         try
         {
+            Periodistas periodistaAEliminar = OEcontext.Periodistas.Where(periodista => periodista.Cedula == unP.Cedula).FirstOrDefault();
+
+            if (periodistaAEliminar == null)
+            {
+                throw new Exception("El periodista ingresado no existe");
+            }
+
             SqlParameter _cedula = new SqlParameter("@Cedula", unP.Cedula);
             SqlParameter _retorno = new SqlParameter("@ret", System.Data.SqlDbType.Int);
 
@@ -156,12 +158,15 @@ public class LogicaModeloEF
 
             if ((int)_retorno.Value == 1)
             {
+                /**
+                 * Acá se pasa el objeto periodistaAEliminar (y no unP)
+                 * porque periodistaAEliminar proviene del contexto
+                 * * de la base de datos.
+                 *
+                 * Rafael, 5/12/2021
+                 */
+                OEcontext.Periodistas.Remove(periodistaAEliminar);
                 OEcontext.SaveChanges();
-            }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unP).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)
@@ -169,10 +174,6 @@ public class LogicaModeloEF
             OEcontext.Entry(unP).State = System.Data.Entity.EntityState.Detached;
 
             throw ex;
-        }
-        finally
-        {
-            OEcontext = null;
         }
     }
 

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -242,6 +242,13 @@ public class LogicaModeloEF
     {
         try
         {
+            Secciones seccionAEliminar = OEcontext.Secciones.Where(seccion => seccion.Nombre == unaS.Nombre).FirstOrDefault();
+
+            if (seccionAEliminar == null)
+            {
+                throw new Exception("La sección ingresada no existe");
+            }
+
             SqlParameter _codigo = new SqlParameter("@CodigoSeccion", unaS.CodigoSeccion);
             SqlParameter _retorno = new SqlParameter("@ret", System.Data.SqlDbType.Int);
 
@@ -260,12 +267,15 @@ public class LogicaModeloEF
 
             if ((int)_retorno.Value == 1)
             {
+                /**
+                 * Acá se pasa el objeto seccionAEliminar (y no unaS)
+                 * porque seccionAEliminar proviene del contexto
+                 * * de la base de datos.
+                 *
+                 * Rafael, 5/12/2021
+                 */
+                OEcontext.Secciones.Remove(seccionAEliminar);
                 OEcontext.SaveChanges();
-            }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)
@@ -273,10 +283,6 @@ public class LogicaModeloEF
             OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
 
             throw ex;
-        }
-        finally
-        {
-            OEcontext = null;
         }
     }
 
@@ -400,6 +406,14 @@ public class LogicaModeloEF
              * que viven en el contexto para cargarlos con la nueva noticia.
              * De lo contrario, EF producirá un error, tal como se documenta
              * en LogicaModelo.ModificarNoticia
+             * 
+             * No tomar esta precaución producirá una excepción al ejecutar
+             * la operación DbContext.SaveChanges: EF detectará que en el contexto
+             * ya hay un objeto con una cierta clave primaria y que se
+             * intenta agregar un objeto diferente con la misma clave primaria
+             * que el objeto anterior
+             * 
+             * Rafael 20/11/2021
              */
             Empleados empleado = RecuperarEmpleadoDesdeContexto(unaN);
 

--- a/Sitio/ABMPeriodistas.aspx.cs
+++ b/Sitio/ABMPeriodistas.aspx.cs
@@ -140,12 +140,6 @@ public partial class ABMPeriodistas : System.Web.UI.Page
 
             PonerFormularioEnEstadoInicial();
 
-            txtCedula.Text = "";
-            txtNombre.Text = "";
-            txtEmail.Text = "";
-
-            PonerFormularioEnEstadoInicial();
-
             LblError.Text = "Baja con Exito";
         }
         catch (System.Web.Services.Protocols.SoapException ex)


### PR DESCRIPTION
Esta propuesta de código busca explorar una implementación alternativa, más cercana a los ejemplos estudiados en clase, para `LogicaModeloEF.EliminarSeccion` y `LogicaModeloEF.EliminarPeriodista`.

Estas implementaciones se testearon dando de baja en el sistema una entidad y luego dándole de alta otra vez. Tanto en la prueba con una sección y como con un periodista no hubo error alguno, lo que parece probar que los objetos fueron eliminados de la base de datos y del `DbContext` del Entity Framework.

## ¿Por qué esta implementación es problemática?
En la última página del enunciado del Obligatorio, se indican los siguientes requisitos:

> - Las acciones de eliminación deberán ejecutar los Stored Procedure a través de EF manualmente. Obligatorio de implementar
> - El resto de acciones de mantenimiento de Periodistas, Secciones y Empleado deberán tener Stored Procedures asociados en el modelo generado. Obligatorio de implementar

El problema parece encontrarse en la frase ***el resto de las acciones de mantenimiento de Periodistas, Secciones...***. A partir de la lectura de estos requisitos, se deduce que los **procedimientos almacenados de eliminación NO deben estar asignados en el modelo generado**.

Sin embargo, si se invoca la operación `DbContext.Remove` sin asignar un procedimiento almacenado de eliminación, se recibe un error con este mensaje: <q>**Cannot find the DeleteFunctionMapping for EntityType 'Secciones' in the mapping file.**</q>

El dilema parece resumirse en lo siguiente:
- Si se asigna el procedimiento almacenado para eliminar de la entidad, el código funciona, pero se viola el requisito indicado
- Si no se asigna el procedimiento almacenado para eliminar de la entidad, el código no funciona, pero se respeta el requisito indicado.

## ¿En qué consisten los cambios realizados?
Como ya adelanté más arriba, se añadió al modelo generado los procedimientos almacenados `EliminarSeccion` y `EliminarPeriodista`. Al hacer la asignación, es necesario tildar la casilla `RowsAffectedParameter`, tal como se indica en [esta respuesta de StackOverflow](https://stackoverflow.com/a/24283369/6951887). Esto tomó un momento de entender, pues en mi VS no se indica el nombre del campo.

Luego, los cambios realizados en `LogicaModeloEF.EliminarSeccion` y `LogicaModelo.EliminarPeriodista` pueden resumirse a lo siguiente:
1. recuperar la entidad a eliminar del contexto 
1. invocar `DbContext.Remove` pasándole como parámetro la entidad a eliminar del contexto --esta invocación debe estar justo antes de invocar `DbContext.SaveChanges`--
1. eliminar bloque `finally` de la operación, pues ya no es necesario anular el objeto `DbContext`.

Por último, se eliminó el setter de la propiedad LogicaModeloEF.OEcontext, pues ya no sería necesario anular este objeto.

## Correcciones adicionales
Eliminé en [LogicaModeloEF.EliminarSeccion](https://github.com/floripas/Obligatorio/commit/a1e22f54c9c6aa229993cdb804354cc766fa0872) y [LogicaModelo.EliminarPeriodista](https://github.com/floripas/Obligatorio/commit/bcf0bf6fc7df4470dac6853e2af5aacb2f1d33c6) el bloque `else` que constituía el último caso de la evaluación de lo que devuelve la base de datos. La razón es que estos métodos ya incluían todos los casos posibles (4 en total) de los resultados. 

Para terminar, hice un [pequeño cambio en ABMPeriodistas.aspx.cs](https://github.com/floripas/Obligatorio/commit/eef9cff78085e400ad6ed10295210bc16339a394), porque la operación `ABMPeriodistas.btnBaja_Click` limpiaba el formulario 3 veces. Ahora solo lo hace una vez.