### PR TITLE
Comentario de explicación de anulación de DbContext

### DIFF
--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -172,6 +172,15 @@ public class LogicaModeloEF
         }
         finally
         {
+            /**
+             * Aquí el contexto se anula porque eliminó el registro en la base de datos
+             * pero el objeto correspondiente todavía persiste en el contexto.
+             * 
+             * Para eliminar el objeto del contexto, es posible anular el contexto,
+             * tal como se indica en esta respuesta de StackOverflow:
+             * 
+             * https://stackoverflow.com/questions/27423059/how-do-i-clear-tracked-entities-in-entity-framework/49561627#49561627
+             */
             OEcontext = null;
         }
     }
@@ -276,7 +285,15 @@ public class LogicaModeloEF
         }
         finally
         {
-            OEcontext = null;
+            /**
+             * Aquí el contexto se anula porque eliminó el registro en la base de datos
+             * pero el objeto correspondiente todavía persiste en el contexto.
+             * 
+             * Para eliminar el objeto del contexto, es posible anular el contexto,
+             * tal como se indica en esta respuesta de StackOverflow:
+             * 
+             * https://stackoverflow.com/questions/27423059/how-do-i-clear-tracked-entities-in-entity-framework/49561627#49561627
+             */
         }
     }
 

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -158,11 +158,6 @@ public class LogicaModeloEF
             {
                 OEcontext.SaveChanges();
             }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unP).State = System.Data.Entity.EntityState.Detached;
-            }
         }
         catch (Exception ex)
         {
@@ -270,11 +265,6 @@ public class LogicaModeloEF
             if ((int)_retorno.Value == 1)
             {
                 OEcontext.SaveChanges();
-            }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)


### PR DESCRIPTION
Añadí un comentario para explicar por qué buscábamos anular el objeto `DbContext` en las operaciones `LogicaModeloEF.EliminarSeccion` y `LogicaModeloEF.EliminarPeriodista`.

Pensé que esto ya había quedado en el código, pero en realidad solo lo había hecho en la [pull request pertinente](https://github.com/floripas/Obligatorio/pull/12).