### PR TITLE
Explorar baja cambio estado

### DIFF
--- a/ModeloEF/Obligatorio.edmx
+++ b/ModeloEF/Obligatorio.edmx
@@ -352,9 +352,6 @@
                   <ScalarProperty Name="Nombre" ParameterName="Nombre" Version="Current" />
                   <ScalarProperty Name="Cedula" ParameterName="Cedula" Version="Current" />
                 </UpdateFunction>
-                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarPeriodista" RowsAffectedParameter="ret">
-                  <ScalarProperty Name="Cedula" ParameterName="Cedula" />
-                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>
@@ -375,9 +372,6 @@
                   <ScalarProperty Name="Nombre" ParameterName="nuevoNombre" Version="Current" />
                   <ScalarProperty Name="CodigoSeccion" ParameterName="codigoSeccion" Version="Current" />
                 </UpdateFunction>
-                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarSeccion" RowsAffectedParameter="ret">
-                  <ScalarProperty Name="CodigoSeccion" ParameterName="CodigoSeccion" />
-                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>

--- a/ModeloEF/Obligatorio.edmx
+++ b/ModeloEF/Obligatorio.edmx
@@ -352,6 +352,9 @@
                   <ScalarProperty Name="Nombre" ParameterName="Nombre" Version="Current" />
                   <ScalarProperty Name="Cedula" ParameterName="Cedula" Version="Current" />
                 </UpdateFunction>
+                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarPeriodista" RowsAffectedParameter="ret">
+                  <ScalarProperty Name="Cedula" ParameterName="Cedula" />
+                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>
@@ -372,6 +375,9 @@
                   <ScalarProperty Name="Nombre" ParameterName="nuevoNombre" Version="Current" />
                   <ScalarProperty Name="CodigoSeccion" ParameterName="codigoSeccion" Version="Current" />
                 </UpdateFunction>
+                <DeleteFunction FunctionName="ObligatorioModel.Store.EliminarSeccion" RowsAffectedParameter="ret">
+                  <ScalarProperty Name="CodigoSeccion" ParameterName="CodigoSeccion" />
+                </DeleteFunction>
               </ModificationFunctionMapping>
             </EntityTypeMapping>
           </EntitySetMapping>

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -271,11 +271,11 @@ public class LogicaModeloEF
                 /**
                  * Acá se pasa el objeto seccionAEliminar (y no unaS)
                  * porque seccionAEliminar proviene del contexto
-                 * * de la base de datos.
+                 * de la base de datos.
                  *
                  * Rafael, 5/12/2021
                  */
-                OEcontext.Secciones.Remove(seccionAEliminar);
+                OEcontext.Entry(seccionAEliminar).State = System.Data.Entity.EntityState.Detached;
                 OEcontext.SaveChanges();
             }
         }

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -21,11 +21,6 @@ public class LogicaModeloEF
             }
             return _OEcontext;
         }
-        //para poder anular el contexto y reinstanciarlo otra vez
-        set
-        {
-            _OEcontext = value;
-        }
     }
 
 
@@ -138,6 +133,13 @@ public class LogicaModeloEF
     {
         try
         {
+            Periodistas periodistaAEliminar = OEcontext.Periodistas.Where(periodista => periodista.Cedula == unP.Cedula).FirstOrDefault();
+
+            if (periodistaAEliminar == null)
+            {
+                throw new Exception("El periodista ingresado no existe");
+            }
+
             SqlParameter _cedula = new SqlParameter("@Cedula", unP.Cedula);
             SqlParameter _retorno = new SqlParameter("@ret", System.Data.SqlDbType.Int);
 
@@ -156,12 +158,15 @@ public class LogicaModeloEF
 
             if ((int)_retorno.Value == 1)
             {
+                /**
+                 * Acá se pasa el objeto periodistaAEliminar (y no unP)
+                 * porque periodistaAEliminar proviene del contexto
+                 * * de la base de datos.
+                 *
+                 * Rafael, 5/12/2021
+                 */
+                OEcontext.Periodistas.Remove(periodistaAEliminar);
                 OEcontext.SaveChanges();
-            }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unP).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)
@@ -169,10 +174,6 @@ public class LogicaModeloEF
             OEcontext.Entry(unP).State = System.Data.Entity.EntityState.Detached;
 
             throw ex;
-        }
-        finally
-        {
-            OEcontext = null;
         }
     }
 

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -242,6 +242,13 @@ public class LogicaModeloEF
     {
         try
         {
+            Secciones seccionAEliminar = OEcontext.Secciones.Where(seccion => seccion.Nombre == unaS.Nombre).FirstOrDefault();
+
+            if (seccionAEliminar == null)
+            {
+                throw new Exception("La sección ingresada no existe");
+            }
+
             SqlParameter _codigo = new SqlParameter("@CodigoSeccion", unaS.CodigoSeccion);
             SqlParameter _retorno = new SqlParameter("@ret", System.Data.SqlDbType.Int);
 
@@ -260,12 +267,15 @@ public class LogicaModeloEF
 
             if ((int)_retorno.Value == 1)
             {
+                /**
+                 * Acá se pasa el objeto seccionAEliminar (y no unaS)
+                 * porque seccionAEliminar proviene del contexto
+                 * * de la base de datos.
+                 *
+                 * Rafael, 5/12/2021
+                 */
+                OEcontext.Secciones.Remove(seccionAEliminar);
                 OEcontext.SaveChanges();
-            }
-            else
-            {
-                OEcontext.SaveChanges();
-                OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
             }
         }
         catch (Exception ex)
@@ -273,10 +283,6 @@ public class LogicaModeloEF
             OEcontext.Entry(unaS).State = System.Data.Entity.EntityState.Detached;
 
             throw ex;
-        }
-        finally
-        {
-            OEcontext = null;
         }
     }
 
@@ -400,6 +406,14 @@ public class LogicaModeloEF
              * que viven en el contexto para cargarlos con la nueva noticia.
              * De lo contrario, EF producirá un error, tal como se documenta
              * en LogicaModelo.ModificarNoticia
+             * 
+             * No tomar esta precaución producirá una excepción al ejecutar
+             * la operación DbContext.SaveChanges: EF detectará que en el contexto
+             * ya hay un objeto con una cierta clave primaria y que se
+             * intenta agregar un objeto diferente con la misma clave primaria
+             * que el objeto anterior
+             * 
+             * Rafael 20/11/2021
              */
             Empleados empleado = RecuperarEmpleadoDesdeContexto(unaN);
 

--- a/Servicio/App_Code/LogicaModeloEF.cs
+++ b/Servicio/App_Code/LogicaModeloEF.cs
@@ -161,11 +161,11 @@ public class LogicaModeloEF
                 /**
                  * Acá se pasa el objeto periodistaAEliminar (y no unP)
                  * porque periodistaAEliminar proviene del contexto
-                 * * de la base de datos.
+                 * de la base de datos.
                  *
                  * Rafael, 5/12/2021
                  */
-                OEcontext.Periodistas.Remove(periodistaAEliminar);
+                OEcontext.Entry(periodistaAEliminar).State = System.Data.Entity.EntityState.Detached;
                 OEcontext.SaveChanges();
             }
         }

--- a/Sitio/ABMPeriodistas.aspx.cs
+++ b/Sitio/ABMPeriodistas.aspx.cs
@@ -140,12 +140,6 @@ public partial class ABMPeriodistas : System.Web.UI.Page
 
             PonerFormularioEnEstadoInicial();
 
-            txtCedula.Text = "";
-            txtNombre.Text = "";
-            txtEmail.Text = "";
-
-            PonerFormularioEnEstadoInicial();
-
             LblError.Text = "Baja con Exito";
         }
         catch (System.Web.Services.Protocols.SoapException ex)


### PR DESCRIPTION
Esta propuesta está preparada a partir de este [borrador de pull request](https://github.com/floripas/Obligatorio/pull/18).

Acá la idea es explorar si es posible efectivamente eliminar una sección y un periodista del DbContext, **sin procedimiento almacenado asociada para eliminar en el modelo**, cambiando el estado de una entidad a `Detached`. 

La respuesta es: **sí, es posible**.

## Sin procedimientos eliminar asociados
Se puede comprobar [en este commit](https://github.com/floripas/Obligatorio/commit/90e5388a29ccb41e6ee8f46bceaac2f7745c3771).

## Pero antes no funcionaba; ¿por qué funciona ahora?
La solución al problema es simple, pero pasa por recordar un concepto fundamental: 

**_2 objetos A y B son iguales si y solo si A y B comparten la misma referencia en memoria_**.

Para cambiar efectivamente el estado de una entidad y ponerla en `Detached`, es necesario seguir los siguientes pasos en este orden:

1. Recuperar la entidad a eliminar en el `DbContext`
2. Hacer el cambio de estado de *esa entidad*, no del parámetro recibido
3. Guardar los cambios

Es necesario el paso 1 porque, si se pasa el objeto recibido por parámetro en `LogicaModeloEF.EliminarSeccion` o en `LogicaModeloEF.EliminarPeriodista`, ***no se pondrá el objeto correcto en estado `Detached`***. 

Según esta hipótesis, es posible que Entity Framework no haga nada porque, después de todo, el contexto no tiene una referencia en memoria del objeto recibido por parámetro, en primer lugar.
